### PR TITLE
add Python 3.11 support and improve documentation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - name: Checkout codes

--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,4 @@ cython_debug/
 # Other files and folders
 tmp/
 .ipython/
+.ruff_cache/

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -21,7 +21,7 @@ Using a virtual environment helps avoid conflicts with other Python projects and
 - Create a new virtual environment named `.venv`:
 
     ```bash
-    python3.11 -m venv .venv
+    python3 -m venv .venv
     ```
 
 - Activate the virtual environment:

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -6,7 +6,7 @@ This guide provides detailed instructions for installing the [gfw-api-python-cli
 
 Before you begin, ensure you have the following installed on your system:
 
-- **Python** >= 3.12 ([Download Python](https://www.python.org/downloads/))
+- **Python** >= 3.11 ([Download Python](https://www.python.org/downloads/))
 - **pip** >= 25 ([Upgrade pip](https://pip.pypa.io/en/stable/installation/))
 - **Virtual Environment Tool** ([venv](https://docs.python.org/3/library/venv.html))
 
@@ -21,7 +21,7 @@ Using a virtual environment helps avoid conflicts with other Python projects and
 - Create a new virtual environment named `.venv`:
 
     ```bash
-    python3.12 -m venv .venv
+    python3.11 -m venv .venv
     ```
 
 - Activate the virtual environment:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 <!-- start: badges -->
 [![ci](https://github.com/GlobalFishingWatch/gfw-api-python-client/actions/workflows/ci.yaml/badge.svg)](https://github.com/GlobalFishingWatch/gfw-api-python-client/actions/workflows/ci.yaml)
 [![codecov](https://codecov.io/gh/GlobalFishingWatch/gfw-api-python-client/branch/develop/graph/badge.svg?token=w4R4VZB5RY)](https://codecov.io/gh/GlobalFishingWatch/gfw-api-python-client)
+[![pypi - version](https://img.shields.io/pypi/v/gfw-api-python-client)](https://pypi.org/project/gfw-api-python-client/)
+[![pypi - python versions](https://img.shields.io/pypi/pyversions/gfw-api-python-client)](https://pypi.org/project/gfw-api-python-client/)
 [![license](https://img.shields.io/badge/license-Apache%202-blue)](https://github.com/GlobalFishingWatch/gfw-api-python-client/blob/main/LICENSE)
 
 [![pre-commit action](https://github.com/GlobalFishingWatch/gfw-api-python-client/actions/workflows/pre-commit.yaml/badge.svg)](https://github.com/GlobalFishingWatch/gfw-api-python-client/actions/workflows/pre-commit.yaml)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 [![pre-commit action](https://github.com/GlobalFishingWatch/gfw-api-python-client/actions/workflows/pre-commit.yaml/badge.svg)](https://github.com/GlobalFishingWatch/gfw-api-python-client/actions/workflows/pre-commit.yaml)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
+[![mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
 [![ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![conventional commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
@@ -19,6 +20,7 @@ Python package for accessing data from Global Fishing Watch (GFW) APIs.
 > **Important:**
 The `gfw-api-python-client` version 1 directly corresponds to Global Fishing Watch API [version 3](https://globalfishingwatch.org/our-apis/documentation#version-3-api). As of April 30th, 2024, API version 3 is the standard. For the most recent API updates, refer to our [API release notes](https://globalfishingwatch.org/our-apis/documentation#api-release-notes).
 
+## Introduction
 
 The `gfw-api-python-client` simplifies access to Global Fishing Watch (GFW) data through [our APIs](https://globalfishingwatch.org/our-apis/documentation#introduction]). It offers straightforward functions for retrieving GFW data. For R users, we also provide the gfwr package; learn more [here](https://globalfishingwatch.github.io/gfwr/)
 
@@ -34,29 +36,26 @@ The Global Fishing Watch Python package currently works with the following APIs:
 
 > **Note**: See the [Terms of Use](https://globalfishingwatch.org/our-apis/documentation#reference-data) page for GFW APIs for information on our API licenses and rate limits.
 
+## Requirements
+
+- [Python >= 3.12](https://www.python.org/downloads/)
+- [pip >= 25](https://pip.pypa.io/en/stable/installation/)
+- [venv - Python's built-in virtual environment tool](https://docs.python.org/3/library/venv.html)
+- [API access token from the Global Fishing Watch API portal](https://globalfishingwatch.org/our-apis/tokens)
+
 ## Installation
 
-To start using `gfw-api-python-client`, ensure you have [Python 3.12+](https://realpython.com/installing-python/) installed on your system. It's recommended to install the package in a [virtual environment](https://docs.python.org/3/library/venv.html) using [pip](https://pip.pypa.io/en/stable/).
-
-### Linux/macOS
+You can install `gfw-api-python-client` using `pip`:
 
 ```bash
-python3.12 -m venv .venv
-source venv/bin/activate
 pip install gfw-api-python-client
 ```
 
-### Windows
-
-```batch
-python3.12 -m venv .venv
-venv\Scripts\activate
-pip install gfw-api-python-client
-```
+For detailed instructions—including how to set up a virtual environment—refer to the [Installation Guide](https://globalfishingwatch.github.io/gfw-api-python-client/installation.html) in the documentation.
 
 ## Usage
 
-Once installed, you can import and use `gfw-api-python-client` in your code:
+After installation, you can start using `gfw-api-python-client` by importing it into your Python code:
 
 ```python
 import gfwapiclient as gfw
@@ -66,23 +65,28 @@ gfw_client = gfw.Client(
 )
 ```
 
-## Authorization
+For step-by-step instructions and examples, see the [Getting Started](https://globalfishingwatch.github.io/gfw-api-python-client/getting-started.html) and [Usage Guides](https://globalfishingwatch.github.io/gfw-api-python-client/usage-guides/index.html) in the documentation.
 
-To use the `gfw-api-python-client`, you need a GFW API access token. You can request this access token from the [GFW API Portal](https://globalfishingwatch.org/our-apis/tokens). Once you have your access token, export it as an environment variable.
+## Documentation
 
+The full project documentation is available at [globalfishingwatch.github.io/gfw-api-python-client](https://globalfishingwatch.github.io/gfw-api-python-client/index.html).
 
-### Linux/macOS
+To get started with the basics, head over to the [Getting Started](https://globalfishingwatch.github.io/gfw-api-python-client/getting-started.html) guide.
 
-```bash
-export GFW_API_ACCESS_TOKEN="<PASTE_YOUR_GFW_API_ACCESS_TOKEN_HERE>"
-```
+For detailed instructions and examples on interacting with the various APIs offered by Global Fishing Watch, explore the [Usage Guides](https://globalfishingwatch.github.io/gfw-api-python-client/usage-guides/index.html) section.
 
-### Windows
-
-```powershell
-$env:GFW_API_ACCESS_TOKEN = "<PASTE_YOUR_GFW_API_ACCESS_TOKEN_HERE>"
-```
+For a complete reference of all available classes, methods, and modules, see the [API Reference](https://globalfishingwatch.github.io/gfw-api-python-client/apidocs/index.html) section.
 
 ## Contributing
 
-We welcome all contributions to improve the package!. Please read our [Contribution Guide](https://github.com/GlobalFishingWatch/gfw-api-python-client/blob/develop/CONTRIBUTING.md) and reach out!.
+We welcome and appreciate contributions of all kinds to help improve this package!
+
+Before getting started, please take a moment to review the following guides:
+
+- [Contribution Guide](https://globalfishingwatch.github.io/gfw-api-python-client/development-guides/contributing.html) – Learn how to propose changes, submit pull requests, and understand our development process.
+
+- [Setup Guide](https://globalfishingwatch.github.io/gfw-api-python-client/development-guides/setup.html) – Get your development environment up and running.
+
+- [Git Workflow](https://globalfishingwatch.github.io/gfw-api-python-client/development-guides/git-workflow.html) – Understand our branching strategy and commit conventions.
+
+If you have questions, ideas, or run into issues, feel free to [open an issue](https://github.com/GlobalFishingWatch/gfw-api-python-client/issues) or reach out — we’d love to hear from you!

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The Global Fishing Watch Python package currently works with the following APIs:
 
 ## Requirements
 
-- [Python >= 3.12](https://www.python.org/downloads/)
+- [Python >= 3.11](https://www.python.org/downloads/)
 - [pip >= 25](https://pip.pypa.io/en/stable/installation/)
 - [venv - Python's built-in virtual environment tool](https://docs.python.org/3/library/venv.html)
 - [API access token from the Global Fishing Watch API portal](https://globalfishingwatch.org/our-apis/tokens)

--- a/SETUP.md
+++ b/SETUP.md
@@ -20,7 +20,7 @@ We strongly recommend using a [virtual environment](https://docs.python.org/3/tu
 Here's how to set up your development environment:
 
 ```bash
-python3.11 -m venv .venv
+python3 -m venv .venv
 source .venv/bin/activate
 ```
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -13,14 +13,14 @@ cd gfw-api-python-client
 
 ## Setting Up Your Development Environment
 
-`gfw-api-python-client` is a Python package, and a suitable Python installation (version 3.12 or higher) is required for development. You can download Python from the [official website](https://www.python.org/downloads/).
+`gfw-api-python-client` is a Python package, and a suitable Python installation (version 3.11 or higher) is required for development. You can download Python from the [official website](https://www.python.org/downloads/).
 
 We strongly recommend using a [virtual environment](https://docs.python.org/3/tutorial/venv.html) to isolate the project's dependencies.
 
 Here's how to set up your development environment:
 
 ```bash
-python3.12 -m venv .venv
+python3.11 -m venv .venv
 source .venv/bin/activate
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "gfw-api-python-client"
 version = "1.0.1"
 description = "Python package for accessing data from Global Fishing Watch APIs."
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 license = { text = "Apache License 2.0" }
 authors = [
   { name = "Global Fishing Watch", email = "apis@globalfishingwatch.org" },
@@ -49,6 +49,7 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
@@ -61,6 +62,7 @@ classifiers = [
 ]
 dependencies = [
   "httpx~=0.28",                # Making HTTP requests
+  "typing-extensions~=4.13",    # Backported Type Hints for Python 3.8+
   "pydantic~=2.10",             # Data validation and serialization
   "pydantic-settings~=2.8",     # Type-hinted configurations or settings
   "geojson-pydantic~=1.2",      # Data models for the GeoJSON specification
@@ -139,7 +141,7 @@ Issues = "https://github.com/GlobalFishingWatch/gfw-api-python-client/issues"
 fix = true
 line-length = 88
 src = ["src", "tests"]
-target-version = "py312"
+target-version = "py311"
 
 [tool.ruff.format]
 docstring-code-format = true
@@ -175,7 +177,7 @@ known-first-party = ["gfwapiclient", "tests"]
 convention = "google"
 
 [tool.black]
-target-version = ["py312"]
+target-version = ["py311"]
 line-length = 88
 
 [tool.isort]

--- a/src/gfwapiclient/http/endpoints/base.py
+++ b/src/gfwapiclient/http/endpoints/base.py
@@ -4,11 +4,13 @@ import http
 import json
 import logging
 
-from typing import Any, Dict, List, Optional, Type, Union, override
+from typing import Any, Dict, List, Optional, Type, Union
 
 import httpx
 import mapbox_vector_tile
 import pydantic
+
+from typing_extensions import override
 
 from gfwapiclient.exceptions.http import (
     APIConnectionError,

--- a/src/gfwapiclient/resources/events/list/endpoints.py
+++ b/src/gfwapiclient/resources/events/list/endpoints.py
@@ -1,6 +1,8 @@
 """Global Fishing Watch (GFW) API Python Client - Get All Events API Endpoint."""
 
-from typing import Any, Dict, List, Union, override
+from typing import Any, Dict, List, Union
+
+from typing_extensions import override
 
 from gfwapiclient.exceptions.validation import ResultValidationError
 from gfwapiclient.http.client import HTTPClient

--- a/src/gfwapiclient/resources/fourwings/report/endpoints.py
+++ b/src/gfwapiclient/resources/fourwings/report/endpoints.py
@@ -1,6 +1,8 @@
 """Global Fishing Watch (GFW) API Python Client - 4Wings Report API EndPoint."""
 
-from typing import Any, Dict, List, Union, override
+from typing import Any, Dict, List, Union
+
+from typing_extensions import override
 
 from gfwapiclient.exceptions.validation import ResultValidationError
 from gfwapiclient.http.client import HTTPClient

--- a/src/gfwapiclient/resources/vessels/list/endpoints.py
+++ b/src/gfwapiclient/resources/vessels/list/endpoints.py
@@ -3,7 +3,9 @@
 This module defines the endpoint for retrieving a list of vessels by IDs.
 """
 
-from typing import Any, Dict, List, Union, override
+from typing import Any, Dict, List, Union
+
+from typing_extensions import override
 
 from gfwapiclient.exceptions.validation import ResultValidationError
 from gfwapiclient.http.client import HTTPClient

--- a/src/gfwapiclient/resources/vessels/search/endpoints.py
+++ b/src/gfwapiclient/resources/vessels/search/endpoints.py
@@ -3,7 +3,9 @@
 This module defines the endpoint for searching vessels.
 """
 
-from typing import Any, Dict, List, Union, override
+from typing import Any, Dict, List, Union
+
+from typing_extensions import override
 
 from gfwapiclient.exceptions.validation import ResultValidationError
 from gfwapiclient.http.client import HTTPClient

--- a/tests/http/endpoints/test_abstract_base_end_point.py
+++ b/tests/http/endpoints/test_abstract_base_end_point.py
@@ -2,10 +2,12 @@
 
 import http
 
-from typing import Any, Dict, Optional, override
+from typing import Any, Dict, Optional
 
 import httpx
 import pytest
+
+from typing_extensions import override
 
 from gfwapiclient.http.client import HTTPClient
 from gfwapiclient.http.endpoints.abc import AbstractBaseEndPoint


### PR DESCRIPTION
This:

- Update type annotations and imports to support Python 3.11
- Add Python 3.11 to the CI workflow
- Add Introduction and Requirements sections to README
- Improve Installation, Usage, and Contributing sections in README
- Add PyPI version and Python version badges to README