### PR TITLE
add methods to create fourwings AIS and SAR presence reports

### DIFF
--- a/src/gfwapiclient/resources/fourwings/report/endpoints.py
+++ b/src/gfwapiclient/resources/fourwings/report/endpoints.py
@@ -95,7 +95,7 @@ class FourWingsReportEndPoint(
             ResultValidationError:
                 If the response body does not match the expected format.
         """
-        # expected: {entries: [{"key": [{}]}]}
+        # Expected: {entries: [{"key": [{}]}]}
         if not isinstance(body, dict) or "entries" not in body:
             raise ResultValidationError(
                 message="Expected a list of entries, but got an empty list.",
@@ -103,21 +103,29 @@ class FourWingsReportEndPoint(
             )
 
         # Transforming and reshaping entries
-        report_entries: List[Dict[str, Any]] = body.get("entries", [])
+        report_entries: List[Dict[str, Any]] = body.get("entries", []) or []
         transformed_data: List[Dict[str, Any]] = []
 
         # Loop through "entries" list i.e {"entries": [{"dataset": [{...}]}]}
         for report_entry in report_entries:
-            # Loop through each dataset "entries" list i.e {"dataset": [{...}]}
-            for report_dataset, report_dataset_entries in report_entry.items():
-                # Extract actual report item data i.e [{...}]}
-                for report_dataset_entry in report_dataset_entries or []:
-                    # Reshape
-                    _report_dataset_entry = {
-                        "report_dataset": report_dataset,
-                        **report_dataset_entry,
-                    }
-                    # Append extracted report dataset entry dictionaries
-                    transformed_data.append(_report_dataset_entry)
+            # Process "report_entry", if not empty
+            if isinstance(report_entry, dict):
+                # Loop through each dataset "entries" list i.e {"dataset": [{...}]}
+                for report_dataset, report_dataset_entries in report_entry.items():
+                    # Process "report_dataset_entries", if not empty
+                    if isinstance(report_dataset, str) and isinstance(
+                        report_dataset_entries, list
+                    ):
+                        # Extract actual report item data i.e [{...}]}
+                        for report_dataset_entry in report_dataset_entries or []:
+                            # Process extracted report dataset entry dictionaries, if not empty
+                            if isinstance(report_dataset_entry, dict):
+                                # Reshape
+                                _report_dataset_entry = {
+                                    "report_dataset": report_dataset,
+                                    **report_dataset_entry,
+                                }
+                                # Append extracted report dataset entry dictionaries
+                                transformed_data.append(_report_dataset_entry)
 
         return transformed_data

--- a/src/gfwapiclient/resources/fourwings/resources.py
+++ b/src/gfwapiclient/resources/fourwings/resources.py
@@ -41,6 +41,319 @@ class FourWingsResource(BaseResource):
     for generating reports.
     """
 
+    async def create_fishing_effort_report(
+        self,
+        *,
+        spatial_resolution: Optional[
+            Union[FourWingsReportSpatialResolution, str]
+        ] = None,
+        group_by: Optional[Union[FourWingsReportGroupBy, str]] = None,
+        temporal_resolution: Optional[
+            Union[FourWingsReportTemporalResolution, str]
+        ] = None,
+        filters: Optional[List[str]] = None,
+        start_date: Optional[Union[datetime.date, str]] = None,
+        end_date: Optional[Union[datetime.date, str]] = None,
+        spatial_aggregation: Optional[bool] = None,
+        geojson: Optional[Union[FourWingsGeometry, Dict[str, Any]]] = None,
+        region: Optional[Union[FourWingsReportRegion, Dict[str, Any]]] = None,
+        **kwargs: Dict[str, Any],
+    ) -> FourWingsReportResult:
+        """Create 4Wings AIS apparent fishing effort report for a specified region.
+
+        Generates AIS (Automatic Identification System) apparent fishing effort report
+        from the 4Wings API based on the provided parameters to visualize apparent
+        fishing activity based on AIS data.
+
+        Generated report can serves following analytical needs:
+
+        - Fisheries compliance monitoring
+        - Fleet management
+        - Supply chain visibility
+
+        Args:
+            spatial_resolution (Optional[Union[FourWingsReportSpatialResolution, str]], default="HIGH"):
+                Spatial resolution of the report. Defaults to `"HIGH"`.
+                Allowed values: `"HIGH"`, `"LOW"`.
+                Example: `"HIGH"`.
+
+            group_by (Optional[Union[FourWingsReportGroupBy, str]], default=None):
+                Grouping criteria for the report. Defaults to `None`.
+                Allowed values: `"VESSEL_ID"`, `"FLAG"`, `"GEARTYPE"`, `"FLAGANDGEARTYPE"`, `"MMSI"`.
+                Example: `"FLAG"`.
+
+            temporal_resolution (Optional[Union[FourWingsReportTemporalResolution, str]], default="HOURLY"):
+                Temporal resolution of the report. Defaults to `"HOURLY"`
+                Allowed values: `"HOURLY"`, `"DAILY"`, `"MONTHLY"`, `"YEARLY"`, `"ENTIRE"`.
+                Example: `"HOURLY"`.
+
+            filters (Optional[List[str]], default=None):
+                Filters to apply to the report. Defaults to `None`.
+                Allowed filters: `flag`, `geartype` and `vessel_id`.
+                Example: `["flag in ('ESP', 'FRA')"]`.
+
+            start_date (Optional[Union[datetime.date, str]], default=None):
+                Start date for the report. Used to build `date_range`. Defaults to `None`.
+                Allowed values: A string in `ISO 8601 format` or `datetime.date` instance.
+                Example: `datetime.date(2021, 1, 1)` or `"2021-01-01"`.
+
+            end_date (Optional[Union[datetime.date, str]], default=None):
+                End date for the report. Used to build `date_range`. Defaults to `None`.
+                Allowed values: A string in `ISO 8601 format` or `datetime.date` instance.
+                Example: `datetime.date(2021, 1, 15)` or `"2021-01-15"`.
+
+            spatial_aggregation (Optional[bool], default=None):
+                Whether to spatially aggregate the report. Defaults to `None`.
+                Example: `True`.
+
+            geojson (Optional[Union[FourWingsGeometry, Dict[str, Any]]], default=None):
+                Custom GeoJSON geometry to filter the report. Defaults to `None`.
+                Example: `{"type": "Polygon", "coordinates": [...]}`.
+
+            region (Optional[Union[FourWingsReportRegion, Dict[str, Any]]], default=None):
+                Predefined region information to filter the report. Defaults to `None`.
+                Example: `{"dataset": "public-eez-areas", "id": "5690"}`.
+
+            **kwargs (Dict[str, Any]):
+                Additional keyword arguments.
+
+        Returns:
+            FourWingsReportResult:
+                The generated 4Wings report.
+
+        Raises:
+            GFWAPIClientError:
+                If the API request fails.
+
+            RequestParamsValidationError:
+                If the request parameters are invalid.
+
+            RequestBodyValidationError:
+                If the request body is invalid.
+        """
+        result: FourWingsReportResult = await self.create_report(
+            spatial_resolution=spatial_resolution,
+            group_by=group_by,
+            temporal_resolution=temporal_resolution,
+            datasets=[FourWingsReportDataset.FISHING_EFFORT_LATEST],
+            filters=filters,
+            start_date=start_date,
+            end_date=end_date,
+            spatial_aggregation=spatial_aggregation,
+            geojson=geojson,
+            region=region,
+            **kwargs,
+        )
+        return result
+
+    async def create_ais_presence_report(
+        self,
+        *,
+        spatial_resolution: Optional[
+            Union[FourWingsReportSpatialResolution, str]
+        ] = None,
+        group_by: Optional[Union[FourWingsReportGroupBy, str]] = None,
+        temporal_resolution: Optional[
+            Union[FourWingsReportTemporalResolution, str]
+        ] = None,
+        filters: Optional[List[str]] = None,
+        start_date: Optional[Union[datetime.date, str]] = None,
+        end_date: Optional[Union[datetime.date, str]] = None,
+        spatial_aggregation: Optional[bool] = None,
+        geojson: Optional[Union[FourWingsGeometry, Dict[str, Any]]] = None,
+        region: Optional[Union[FourWingsReportRegion, Dict[str, Any]]] = None,
+        **kwargs: Dict[str, Any],
+    ) -> FourWingsReportResult:
+        """Create 4Wings AIS vessel presence report for a specified region.
+
+        Generates AIS (Automatic Identification System) apparent fishing effort report
+        from the 4Wings API based on the provided parameters to visualize any vessel
+        type presence and movement patterns based on AIS data.
+
+        Generated report can serves following analytical needs:
+
+        - Port traffic analysis
+        - Fleet management
+        - Supply chain visibility
+
+        Args:
+            spatial_resolution (Optional[Union[FourWingsReportSpatialResolution, str]], default="HIGH"):
+                Spatial resolution of the report. Defaults to `"HIGH"`.
+                Allowed values: `"HIGH"`, `"LOW"`.
+                Example: `"HIGH"`.
+
+            group_by (Optional[Union[FourWingsReportGroupBy, str]], default=None):
+                Grouping criteria for the report. Defaults to `None`.
+                Allowed values: `"VESSEL_ID"`, `"FLAG"`, `"GEARTYPE"`, `"FLAGANDGEARTYPE"`, `"MMSI"`.
+                Example: `"FLAG"`.
+
+            temporal_resolution (Optional[Union[FourWingsReportTemporalResolution, str]], default="HOURLY"):
+                Temporal resolution of the report. Defaults to `"HOURLY"`
+                Allowed values: `"HOURLY"`, `"DAILY"`, `"MONTHLY"`, `"YEARLY"`, `"ENTIRE"`.
+                Example: `"HOURLY"`.
+
+            filters (Optional[List[str]], default=None):
+                Filters to apply to the report. Defaults to `None`.
+                Allowed filters: `flag`, `vessel_type`, and `speed`.
+                Example: `["flag in ('ESP', 'FRA')"]`.
+
+            start_date (Optional[Union[datetime.date, str]], default=None):
+                Start date for the report. Used to build `date_range`. Defaults to `None`.
+                Allowed values: A string in `ISO 8601 format` or `datetime.date` instance.
+                Example: `datetime.date(2021, 1, 1)` or `"2021-01-01"`.
+
+            end_date (Optional[Union[datetime.date, str]], default=None):
+                End date for the report. Used to build `date_range`. Defaults to `None`.
+                Allowed values: A string in `ISO 8601 format` or `datetime.date` instance.
+                Example: `datetime.date(2021, 1, 15)` or `"2021-01-15"`.
+
+            spatial_aggregation (Optional[bool], default=None):
+                Whether to spatially aggregate the report. Defaults to `None`.
+                Example: `True`.
+
+            geojson (Optional[Union[FourWingsGeometry, Dict[str, Any]]], default=None):
+                Custom GeoJSON geometry to filter the report. Defaults to `None`.
+                Example: `{"type": "Polygon", "coordinates": [...]}`.
+
+            region (Optional[Union[FourWingsReportRegion, Dict[str, Any]]], default=None):
+                Predefined region information to filter the report. Defaults to `None`.
+                Example: `{"dataset": "public-eez-areas", "id": "5690"}`.
+
+            **kwargs (Dict[str, Any]):
+                Additional keyword arguments.
+
+        Returns:
+            FourWingsReportResult:
+                The generated 4Wings report.
+
+        Raises:
+            GFWAPIClientError:
+                If the API request fails.
+
+            RequestParamsValidationError:
+                If the request parameters are invalid.
+
+            RequestBodyValidationError:
+                If the request body is invalid.
+        """
+        result: FourWingsReportResult = await self.create_report(
+            spatial_resolution=spatial_resolution,
+            group_by=group_by,
+            temporal_resolution=temporal_resolution,
+            datasets=[FourWingsReportDataset.PRESENCE_LATEST],
+            filters=filters,
+            start_date=start_date,
+            end_date=end_date,
+            spatial_aggregation=spatial_aggregation,
+            geojson=geojson,
+            region=region,
+            **kwargs,
+        )
+        return result
+
+    async def create_sar_presence_report(
+        self,
+        *,
+        spatial_resolution: Optional[
+            Union[FourWingsReportSpatialResolution, str]
+        ] = None,
+        group_by: Optional[Union[FourWingsReportGroupBy, str]] = None,
+        temporal_resolution: Optional[
+            Union[FourWingsReportTemporalResolution, str]
+        ] = None,
+        filters: Optional[List[str]] = None,
+        start_date: Optional[Union[datetime.date, str]] = None,
+        end_date: Optional[Union[datetime.date, str]] = None,
+        spatial_aggregation: Optional[bool] = None,
+        geojson: Optional[Union[FourWingsGeometry, Dict[str, Any]]] = None,
+        region: Optional[Union[FourWingsReportRegion, Dict[str, Any]]] = None,
+        **kwargs: Dict[str, Any],
+    ) -> FourWingsReportResult:
+        """Create 4Wings SAR vessel detections report for a specified region.
+
+        Generates SAR (Synthetic-Aperture Radar) vessel detections report.
+
+        Generated report can serves following analytical needs:
+
+        - Dark vessel detection
+        - Remote area surveillance
+
+        Args:
+            spatial_resolution (Optional[Union[FourWingsReportSpatialResolution, str]], default="HIGH"):
+                Spatial resolution of the report. Defaults to `"HIGH"`.
+                Allowed values: `"HIGH"`, `"LOW"`.
+                Example: `"HIGH"`.
+
+            group_by (Optional[Union[FourWingsReportGroupBy, str]], default=None):
+                Grouping criteria for the report. Defaults to `None`.
+                Allowed values: `"VESSEL_ID"`, `"FLAG"`, `"GEARTYPE"`, `"FLAGANDGEARTYPE"`, `"MMSI"`.
+                Example: `"FLAG"`.
+
+            temporal_resolution (Optional[Union[FourWingsReportTemporalResolution, str]], default="HOURLY"):
+                Temporal resolution of the report. Defaults to `"HOURLY"`
+                Allowed values: `"HOURLY"`, `"DAILY"`, `"MONTHLY"`, `"YEARLY"`, `"ENTIRE"`.
+                Example: `"HOURLY"`.
+
+            filters (Optional[List[str]], default=None):
+                Filters to apply to the report. Defaults to `None`.
+                Allowed filters: `matched`, `flag`, `vessel_id`, `geartype`,
+                `neural_vessel_type` and `shiptype`.
+                Example: `["flag in ('ESP', 'FRA')"]`.
+
+            start_date (Optional[Union[datetime.date, str]], default=None):
+                Start date for the report. Used to build `date_range`. Defaults to `None`.
+                Allowed values: A string in `ISO 8601 format` or `datetime.date` instance.
+                Example: `datetime.date(2021, 1, 1)` or `"2021-01-01"`.
+
+            end_date (Optional[Union[datetime.date, str]], default=None):
+                End date for the report. Used to build `date_range`. Defaults to `None`.
+                Allowed values: A string in `ISO 8601 format` or `datetime.date` instance.
+                Example: `datetime.date(2021, 1, 15)` or `"2021-01-15"`.
+
+            spatial_aggregation (Optional[bool], default=None):
+                Whether to spatially aggregate the report. Defaults to `None`.
+                Example: `True`.
+
+            geojson (Optional[Union[FourWingsGeometry, Dict[str, Any]]], default=None):
+                Custom GeoJSON geometry to filter the report. Defaults to `None`.
+                Example: `{"type": "Polygon", "coordinates": [...]}`.
+
+            region (Optional[Union[FourWingsReportRegion, Dict[str, Any]]], default=None):
+                Predefined region information to filter the report. Defaults to `None`.
+                Example: `{"dataset": "public-eez-areas", "id": "5690"}`.
+
+            **kwargs (Dict[str, Any]):
+                Additional keyword arguments.
+
+        Returns:
+            FourWingsReportResult:
+                The generated 4Wings report.
+
+        Raises:
+            GFWAPIClientError:
+                If the API request fails.
+
+            RequestParamsValidationError:
+                If the request parameters are invalid.
+
+            RequestBodyValidationError:
+                If the request body is invalid.
+        """
+        result: FourWingsReportResult = await self.create_report(
+            spatial_resolution=spatial_resolution,
+            group_by=group_by,
+            temporal_resolution=temporal_resolution,
+            datasets=[FourWingsReportDataset.SAR_PRESENCE_LATEST],
+            filters=filters,
+            start_date=start_date,
+            end_date=end_date,
+            spatial_aggregation=spatial_aggregation,
+            geojson=geojson,
+            region=region,
+            **kwargs,
+        )
+        return result
+
     async def create_report(
         self,
         *,

--- a/src/gfwapiclient/resources/insights/resources.py
+++ b/src/gfwapiclient/resources/insights/resources.py
@@ -59,8 +59,7 @@ class InsightResource(BaseResource):
 
             vessels (Union[List[VesselInsightDatasetVessel], List[Dict[str, Any]]]):
                 List of vessel identifiers to retrieve insights for.
-                Example: `[{"vessel_id": "785101812-2127-e5d2-e8bf-7152c5259f5f",
-                          "dataset_id": "public-global-vessel-identity:latest",}]`.
+                Example: `[{"vessel_id": "785101812-2127-e5d2-e8bf-7152c5259f5f", "dataset_id": "public-global-vessel-identity:latest",}]`.
 
             **kwargs (Dict[str, Any]):
                 Additional keyword arguments.

--- a/tests/integration/test_fourwings_api.py
+++ b/tests/integration/test_fourwings_api.py
@@ -25,13 +25,13 @@ from gfwapiclient.resources.fourwings.report.models.response import (
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_fourwings_create_report_generate_fishing_effort_report_custom_polygon(
+async def test_fourwings_create_report_generate_fishing_effort_report_yearly_grouped_by_flag_custom_polygon(
     gfw_client: gfw.Client,
 ) -> None:
-    """Test generating fishing effort report by year and custom polygon.
+    """Test generating yearly fishing effort report by year and custom polygon.
 
     This test verifies that the `create_report` method correctly retrieves
-    fishing effort data grouped by year for a specified custom polygon.
+    yearly fishing effort data grouped by flag for a specified custom polygon.
     It checks the structure and content of the returned data, ensuring it's a
     valid `FourWingsReportResult` and that the data can be converted to a pandas DataFrame.
     """
@@ -97,13 +97,13 @@ async def test_fourwings_create_report_generate_fishing_effort_report_custom_pol
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_fourwings_create_report_generate_fishing_effort_report_grouped_by_gear_type_russian_eez(
+async def test_fourwings_create_report_generate_fishing_effort_report_monthly_grouped_by_gear_type_russian_eez(
     gfw_client: gfw.Client,
 ) -> None:
-    """Test generating fishing effort report grouped by gear type in Russian EEZ.
+    """Test generating monthly fishing effort report grouped by gear type in Russian EEZ.
 
     This test verifies that the `create_report` method correctly retrieves
-    fishing effort data grouped by gear type within the Exclusive Economic Zone
+    monthly fishing effort data grouped by gear type within the Exclusive Economic Zone
     (EEZ) of Russia. It checks the structure and content of the returned data,
     ensuring it's a valid `FourWingsReportResult` and that the data can be
     converted to a pandas DataFrame.
@@ -134,7 +134,7 @@ async def test_fourwings_create_report_generate_fishing_effort_report_grouped_by
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_fourwings_create_report_generate_total_fishing_hours_per_grid_cell_mpa_nasca(
+async def test_fourwings_create_report_generate_total_fishing_hours_per_grid_cell_mpa_dorsal_de_nasca(
     gfw_client: gfw.Client,
 ) -> None:
     """Test generating report with total fishing hours per grid cell in MPA Dorsal de Nasca.
@@ -172,7 +172,7 @@ async def test_fourwings_create_report_generate_total_fishing_hours_per_grid_cel
 @pytest.mark.integration
 @pytest.mark.asyncio
 @pytest.mark.skip
-async def test_fourwings_create_report_generate_total_fishing_hours_per_grid_cell_mpa_nasca_buffer(
+async def test_fourwings_create_report_generate_total_fishing_hours_per_grid_cell_mpa_dorsal_de_nasca_with_buffer(
     gfw_client: gfw.Client,
 ) -> None:
     """Test generating report with total fishing hours per grid cell in MPA Nasca with buffer.
@@ -212,7 +212,7 @@ async def test_fourwings_create_report_generate_total_fishing_hours_per_grid_cel
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_fourwings_create_report_generate_region_daily_gridded_unmatched_detections_chile(
+async def test_fourwings_create_report_generate_region_daily_gridded_sar_presence_unmatched_chile(
     gfw_client: gfw.Client,
 ) -> None:
     """Test generating daily gridded SAR presence data with unmatched detections in Chile.
@@ -234,6 +234,117 @@ async def test_fourwings_create_report_generate_region_daily_gridded_unmatched_d
         region={
             "dataset": "public-eez-areas",
             "id": "8465",
+        },
+    )
+
+    data: List[FourWingsReportItem] = cast(List[FourWingsReportItem], result.data())
+    assert isinstance(result, FourWingsReportResult)
+    assert len(data) >= 1, "Expected at least one FourWingsReportItem."
+    assert isinstance(data[0], FourWingsReportItem)
+
+    df: pd.DataFrame = cast(pd.DataFrame, result.df())
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) >= 1, "Expected at least one row in the DataFrame."
+    assert list(df.columns) == list(dict(data[0]).keys())
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_fourwings_create_report_generate_sar_vessel_detection_matched_eez(
+    gfw_client: gfw.Client,
+) -> None:
+    """Test generating SAR vessel detection report filtered by matched=true in EEZ.
+
+    This test verifies that the `create_report` method correctly retrieves SAR vessel
+    detection data filtered by matched='true' within the Exclusive Economic Zone (EEZ).
+    It checks the structure and content of the returned data, ensuring it's a valid
+    `FourWingsReportResult` and that the data can be converted to a pandas DataFrame.
+    """
+    result: FourWingsReportResult = await gfw_client.fourwings.create_report(
+        spatial_resolution="HIGH",
+        temporal_resolution="HOURLY",
+        group_by="VESSEL_ID",
+        datasets=["public-global-sar-presence:latest"],
+        start_date="2017-01-01",
+        end_date="2017-01-02",
+        filters=["matched='true'"],
+        region={
+            "dataset": "public-eez-areas",
+            "id": "8492",
+        },
+    )
+
+    data: List[FourWingsReportItem] = cast(List[FourWingsReportItem], result.data())
+    assert isinstance(result, FourWingsReportResult)
+    assert len(data) >= 1, "Expected at least one FourWingsReportItem."
+    assert isinstance(data[0], FourWingsReportItem)
+
+    df: pd.DataFrame = cast(pd.DataFrame, result.df())
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) >= 1, "Expected at least one row in the DataFrame."
+    assert list(df.columns) == list(dict(data[0]).keys())
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.skip
+async def test_fourwings_create_report_generate_ais_vessel_presence_daily_grouped_by_vessel_type(
+    gfw_client: gfw.Client,
+) -> None:
+    """Test generating AIS vessel presence report grouped by vessel type in EEZ.
+
+    This test verifies that the `create_report` method correctly retrieves daily AIS
+    vessel presence data grouped by vessel type within the Exclusive Economic Zone (EEZ).
+    It checks the structure and content of the returned data, ensuring it's a valid
+    `FourWingsReportResult` and that the data can be converted to a pandas DataFrame.
+    """
+    result: FourWingsReportResult = await gfw_client.fourwings.create_report(
+        spatial_resolution="LOW",
+        temporal_resolution="DAILY",
+        group_by="VESSEL_TYPE",
+        datasets=["public-global-presence:latest"],
+        start_date="2022-01-01",
+        end_date="2022-05-01",
+        region={
+            "dataset": "public-eez-areas",
+            "id": "5690",
+        },
+    )
+
+    data: List[FourWingsReportItem] = cast(List[FourWingsReportItem], result.data())
+    assert isinstance(result, FourWingsReportResult)
+    assert len(data) >= 1, "Expected at least one FourWingsReportItem."
+    assert isinstance(data[0], FourWingsReportItem)
+
+    df: pd.DataFrame = cast(pd.DataFrame, result.df())
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) >= 1, "Expected at least one row in the DataFrame."
+    assert list(df.columns) == list(dict(data[0]).keys())
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_fourwings_create_report_ais_vessel_presence_daily_filtered_by_cargo_and_carrier(
+    gfw_client: gfw.Client,
+) -> None:
+    """Test retrieving AIS vessel presence report filtered by cargo and carrier vessel types via GET.
+
+    This test verifies that the `create_report` method correctly retrieves AIS vessel presence data
+    filtered by vessel types 'cargo' and 'carrier' within the Exclusive Economic Zone (EEZ).
+    It checks the structure and content of the returned data, ensuring it's a valid
+    `FourWingsReportResult` and that the data can be converted to a pandas DataFrame.
+    """
+    result: FourWingsReportResult = await gfw_client.fourwings.create_report(
+        spatial_resolution="LOW",
+        temporal_resolution="DAILY",
+        group_by="FLAG",
+        datasets=["public-global-presence:latest"],
+        start_date="2022-01-01",
+        end_date="2022-05-01",
+        filters=["vessel_type in ('cargo','carrier')"],
+        region={
+            "dataset": "public-eez-areas",
+            "id": "5690",
         },
     )
 

--- a/tests/resources/fourwings/conftest.py
+++ b/tests/resources/fourwings/conftest.py
@@ -1,8 +1,9 @@
 """Test configurations for `gfwapiclient.resources.fourwings`."""
 
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Optional
 
 import pytest
+import respx
 
 
 @pytest.fixture
@@ -51,3 +52,100 @@ def mock_raw_fourwings_report_item(
         "fourwings/fourwings_report_item.json"
     )
     return raw_four_wings_report_item
+
+
+@pytest.fixture
+def mock_raw_fourwings_report_standard_request_params(
+    mock_raw_fourwings_report_request_params: Dict[str, Any],
+    mock_raw_fourwings_report_request_body: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Fixture for mock standard combined raw four wings report request params.
+
+    Provides a standard combined mock raw four wings report request parameters,
+    excluding the `"datasets"` key from the original parameters and adding fixed
+    start and end dates.
+
+    Args:
+        mock_raw_fourwings_report_request_params (Dict[str, Any]):
+            Mock raw `FourWingsReportParams` sample data.
+
+        mock_raw_fourwings_report_request_body (Dict[str, Any]):
+            Mock raw `FourWingsReportBody` sample data.
+
+    Returns:
+        Dict[str, Any]:
+            Combined raw `FourWingsReportParams` and `FourWingsReportBody` sample data.
+    """
+    start_date: str = "2021-01-01"
+    end_date: str = "2021-01-15"
+
+    mock_raw_fourwings_report_filtered_request_params: Dict[str, Any] = {
+        k: v
+        for k, v in mock_raw_fourwings_report_request_params.items()
+        if k != "datasets"
+    }
+
+    mock_raw_fourwings_report_combined_request_params: Dict[str, Any] = {
+        **mock_raw_fourwings_report_filtered_request_params,
+        **mock_raw_fourwings_report_request_body,
+        "start_date": start_date,
+        "end_date": end_date,
+    }
+
+    return mock_raw_fourwings_report_combined_request_params
+
+
+@pytest.fixture
+def mock_raw_fourwings_report_standard_response(
+    mock_raw_fourwings_report_item: Dict[str, Any],
+    mock_responsex: respx.MockRouter,
+) -> Callable[[Optional[str]], None]:
+    """Fixture for mock standard raw four wings report response body.
+
+    Returns a function to mock a standard four wings report HTTP response body
+    for the given dataset. Uses the `"dataset"` from the mock report item if none is provided.
+
+    Args:
+        mock_raw_fourwings_report_item (Dict[str, Any]):
+            Mock raw `FourWingsReportItem` sample data.
+
+        mock_responsex (respx.MockRouter):
+            Mock respx router instance.
+
+    Returns:
+        Callable[[Optional[str]], None]:
+            A function which when called with an optional dataset,
+            sets up a mocked HTTP response.
+    """
+
+    def _mock_raw_fourwings_report_standard_response(
+        dataset: Optional[str] = None,
+    ) -> None:
+        """Mocks the HTTP POST response for the four wings report endpoint.
+
+        Args:
+            dataset (Optional[str]):
+                The dataset to use in the mock response.
+                Defaults to the dataset from the mock report item if `None`.
+
+        Returns:
+            None
+        """
+        _dataset: str = dataset or mock_raw_fourwings_report_item["report_dataset"]
+        mock_responsex.post("4wings/report").respond(
+            status_code=200,
+            json={
+                "entries": [
+                    {
+                        _dataset: [
+                            {
+                                **mock_raw_fourwings_report_item,
+                                "report_dataset": _dataset,
+                            }
+                        ]
+                    }
+                ]
+            },
+        )
+
+    return _mock_raw_fourwings_report_standard_response

--- a/tests/resources/fourwings/test_resources.py
+++ b/tests/resources/fourwings/test_resources.py
@@ -1,6 +1,6 @@
 """Tests for `gfwapiclient.resources.fourwings.resources`."""
 
-from typing import Any, Dict, List, cast
+from typing import Any, Callable, Dict, List, Optional, cast
 
 import pytest
 import respx
@@ -13,12 +13,80 @@ from gfwapiclient.http.client import HTTPClient
 from gfwapiclient.resources.fourwings.report.models.request import (
     FOURWINGS_REPORT_REQUEST_BODY_VALIDATION_ERROR_MESSAGE,
     FOURWINGS_REPORT_REQUEST_PARAMS_VALIDATION_ERROR_MESSAGE,
+    FourWingsReportDataset,
 )
 from gfwapiclient.resources.fourwings.report.models.response import (
     FourWingsReportItem,
     FourWingsReportResult,
 )
 from gfwapiclient.resources.fourwings.resources import FourWingsResource
+
+
+@pytest.mark.asyncio
+@pytest.mark.respx
+async def test_fourwings_resource_create_fishing_effort_report(
+    mock_http_client: HTTPClient,
+    mock_raw_fourwings_report_standard_request_params: Dict[str, Any],
+    mock_raw_fourwings_report_standard_response: Callable[[Optional[str]], None],
+) -> None:
+    """Test `FourWingsResource` create AIS apparent fishing effort report succeeds with valid response."""
+    mock_raw_fourwings_report_standard_response(
+        FourWingsReportDataset.FISHING_EFFORT_LATEST
+    )
+
+    resource: FourWingsResource = FourWingsResource(http_client=mock_http_client)
+    result: FourWingsReportResult = await resource.create_fishing_effort_report(
+        **mock_raw_fourwings_report_standard_request_params,
+    )
+
+    data = cast(List[FourWingsReportItem], result.data())
+    assert isinstance(result, FourWingsReportResult)
+    assert isinstance(data[0], FourWingsReportItem)
+    assert data[0].report_dataset == FourWingsReportDataset.FISHING_EFFORT_LATEST
+
+
+@pytest.mark.asyncio
+@pytest.mark.respx
+async def test_fourwings_resource_create_ais_presence_report(
+    mock_http_client: HTTPClient,
+    mock_raw_fourwings_report_standard_request_params: Dict[str, Any],
+    mock_raw_fourwings_report_standard_response: Callable[[Optional[str]], None],
+) -> None:
+    """Test `FourWingsResource` create AIS vessel presence report succeeds with valid response."""
+    mock_raw_fourwings_report_standard_response(FourWingsReportDataset.PRESENCE_LATEST)
+
+    resource: FourWingsResource = FourWingsResource(http_client=mock_http_client)
+    result: FourWingsReportResult = await resource.create_ais_presence_report(
+        **mock_raw_fourwings_report_standard_request_params
+    )
+
+    data = cast(List[FourWingsReportItem], result.data())
+    assert isinstance(result, FourWingsReportResult)
+    assert isinstance(data[0], FourWingsReportItem)
+    assert data[0].report_dataset == FourWingsReportDataset.PRESENCE_LATEST
+
+
+@pytest.mark.asyncio
+@pytest.mark.respx
+async def test_fourwings_resource_create_sar_presence_report(
+    mock_http_client: HTTPClient,
+    mock_raw_fourwings_report_standard_request_params: Dict[str, Any],
+    mock_raw_fourwings_report_standard_response: Callable[[Optional[str]], None],
+) -> None:
+    """Test `FourWingsResource` create SAR detections report succeeds with valid response."""
+    mock_raw_fourwings_report_standard_response(
+        FourWingsReportDataset.SAR_PRESENCE_LATEST
+    )
+
+    resource: FourWingsResource = FourWingsResource(http_client=mock_http_client)
+    result: FourWingsReportResult = await resource.create_sar_presence_report(
+        **mock_raw_fourwings_report_standard_request_params
+    )
+
+    data = cast(List[FourWingsReportItem], result.data())
+    assert isinstance(result, FourWingsReportResult)
+    assert isinstance(data[0], FourWingsReportItem)
+    assert data[0].report_dataset == FourWingsReportDataset.SAR_PRESENCE_LATEST
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This:

- Adds methods to create `fishing effort`, `AIS presence`, and `SAR presence` reports in `FourWingsResource`
- Improves validation and safe transformation of nested responses in `FourWingsReportEndPoint`
- Updates unit tests to cover new report methods and edge cases
- Adds integration tests for SAR vessel detection and AIS vessel presence reports