### PR TITLE
build: Add py.typed file to package-data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -261,3 +261,6 @@ where = ["src"]
 include = ["gfwapiclient", "gfwapiclient.*"]
 exclude = ["tests*"]
 namespaces = false
+
+[tool.setuptools.package-data]
+"gfwapiclient" = ["py.typed"]


### PR DESCRIPTION
This PR adds the `src/gfwapiclient/py.typed` marker file and includes this path under pyproject.toml's [tool.setuptools.package-data] section. py.typed marks gfwapiclient as [PEP 561](https://peps.python.org/pep-0561/) compliant. By exporting py.typed with the gfwapiclient you enable other Python projects to use your types without having to add a mypy override.

This project has great type annotations - now users can benefit from those when using your library!