### PR TITLE
implement Bulk Download API resource and client integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ The Global Fishing Watch Python package currently works with the following APIs:
 
 - [Datasets API](https://globalfishingwatch.org/our-apis/documentation#datasets-api): Retrieve fixed offshore infrastructure detections (e.g., oil platforms, wind farms) from Sentinel-1 and Sentinel-2 satellite imagery, from 2017 up to 3 months ago, classified using deep learning.
 
+- [Bulk Download API](https://globalfishingwatch.org/our-apis/documentation#bulk-download-api): Efficiently access and download large-scale datasets to integrate with big data platforms and tools used by data engineers and researchers. Unlike our other APIs ([Map Visualization (4Wings API)](https://globalfishingwatch.org/our-apis/documentation#map-visualization-4wings-api), [Datasets API](https://globalfishingwatch.org/our-apis/documentation#datasets-api) etc.), these datasets may include some **noisy** that are not filtered out.
+
 - [References API](https://globalfishingwatch.org/our-apis/documentation#regions): Access metadata for EEZs, MPAs, and RFMOs to use in [Events API](https://globalfishingwatch.org/our-apis/documentation#events-api) and [Map Visualization (4Wings API)](https://globalfishingwatch.org/our-apis/documentation#map-visualization-4wings-api) requests and analyses.
 
 > **Note:** See the [Data Caveats](https://globalfishingwatch.org/our-apis/documentation#data-caveat) and [Terms of Use](https://globalfishingwatch.org/our-apis/documentation#terms-of-use) pages in the [GFW API documentation](https://globalfishingwatch.org/our-apis/documentation#introduction) for details on GFW data, API licenses, and rate limits.

--- a/src/gfwapiclient/__init__.py
+++ b/src/gfwapiclient/__init__.py
@@ -1,25 +1,52 @@
 """Global Fishing Watch (GFW) API Python Client.
 
-This package provides a Python client for interacting with the Global Fishing Watch (GFW) API,
-specifically `version 3 <https://globalfishingwatch.org/our-apis/documentation#version-3-api>`_.
-It enables access to publicly available API resources, and facilitating the retrieval of the data.
+This package provides a Python client for interacting with the Global Fishing Watch
+(GFW) API version 3.
 
-Features:
+See: https://globalfishingwatch.org/our-apis/documentation#version-3-api
 
-- **4Wings**: Access AIS apparent fishing effort, AIS vessel presence, and SAR vessel detections between 2017 to ~5 days ago.
+See: https://globalfishingwatch.org/our-apis/documentation#in-api-version-3
 
-- **Vessels**: Search and retrieve vessel identity based on AIS self-reported data, combined with authorization and registry data from regional and national registries.
+It enables access to publicly available API resources, and facilitating the retrieval
+of the following APIs data:
 
-- **Events**: Retrieve vessel activity events such as encounters, loitering, port visits, fishing events, and AIS off (aka GAPs).
+- **Map Visualization (4Wings API)**: Access AIS apparent fishing effort,
+AIS vessel presence, and SAR vessel detections between 2017 to ~5 days ago.
 
-- **Insights**: Access vessel insights that combine AIS activity, vessel identity, and public authorizations. Designed to support risk-based decision-making, operational planning, and due diligence—particularly for assessing risks of IUU (Illegal, Unreported, or Unregulated) fishing.
+- **Vessels API**: Search and retrieve vessel identity based on AIS self-reported data,
+combined with authorization and registry data from regional and national registries.
 
-- **Datasets**: Retrieve fixed offshore infrastructure detections (e.g., oil platforms, wind farms) from Sentinel-1 and Sentinel-2 satellite imagery, from 2017 up to 3 months ago, classified using deep learning.
+- **Events API**: Retrieve vessel activity events such as encounters, loitering, port
+visits, fishing events, and AIS off (aka GAPs).
 
-- **References**: Access metadata for EEZs, MPAs, and RFMOs to use in `Events API <https://globalfishingwatch.org/our-apis/documentation#events-api>`_ and `Map Visualization (4Wings API) <https://globalfishingwatch.org/our-apis/documentation#map-visualization-4wings-api>`_ requests and analyses.
+- **Insights API**: Access vessel insights that combine AIS activity, vessel identity,
+and public authorizations. Designed to support risk-based decision-making, operational
+planning, and due diligence—particularly for assessing risks of
+IUU (Illegal, Unreported, or Unregulated) fishing.
 
-For comprehensive details, please refer to the official
-`Global Fishing Watch API Documentation <https://globalfishingwatch.org/our-apis/documentation#version-3-api>`_.
+- **Datasets API**: Retrieve fixed offshore infrastructure detections (e.g.,
+oil platforms, wind farms etc.) from Sentinel-1 and Sentinel-2 satellite imagery,
+from 2017 up to 3 months ago, classified using deep learning.
+
+- **Bulk Download API**: Efficiently access and download large-scale datasets to
+integrate with big data platforms and tools used by data engineers and researchers.
+Unlike our other APIs (4Wings API, Datasets API, etc.), these datasets may include
+some **noisy** that are not filtered out.
+
+- **References**: Access metadata for EEZs, MPAs, and RFMOs to use in Events API and
+4Wings API requests and analyses.
+
+For more details on the data, API licenses, and rate limits, please refer to
+the official Global Fishing Watch API documentation:
+
+See: https://globalfishingwatch.org/our-apis/documentation#introduction
+
+For more details on the data caveats and terms of use, please refer to the
+official Global Fishing Watch API documentation:
+
+See: https://globalfishingwatch.org/our-apis/documentation#data-caveat
+
+See: https://globalfishingwatch.org/our-apis/documentation#terms-of-use
 """
 
 from gfwapiclient.__version__ import __version__

--- a/src/gfwapiclient/client/client.py
+++ b/src/gfwapiclient/client/client.py
@@ -8,6 +8,7 @@ import httpx
 
 from gfwapiclient.http import HTTPClient
 from gfwapiclient.resources import (
+    BulkDownloadResource,
     DatasetResource,
     EventResource,
     FourWingsResource,
@@ -55,6 +56,9 @@ class Client:
         datasets (DatasetResource):
             Access to the datasets data resources.
 
+        bulk_downloads (BulkDownloadResource):
+            Access to the Bulk download API resources.
+
         references (ReferenceResource):
             Access to the reference data resources.
     """
@@ -64,6 +68,7 @@ class Client:
     _events: EventResource
     _insights: InsightResource
     _datasets: DatasetResource
+    _bulk_downloads: BulkDownloadResource
     _references: ReferenceResource
 
     def __init__(
@@ -244,6 +249,26 @@ class Client:
         if not hasattr(self, "_datasets"):
             self._datasets = DatasetResource(http_client=self._http_client)
         return self._datasets
+
+    @property
+    def bulk_downloads(self) -> BulkDownloadResource:
+        """Bulk download API resource.
+
+        Provides access to the Bulk Download API resources, which allow to
+        efficiently create, retrieve, and download bulk reports data and files.
+
+        For more details on the Bulk Download API, please refer to the official
+        Global Fishing Watch API documentation:
+
+        See: https://globalfishingwatch.org/our-apis/documentation#bulk-download-api
+
+        Returns:
+            BulkDownloadResource:
+                The bulk download resource instance.
+        """
+        if not hasattr(self, "_bulk_downloads"):
+            self._bulk_downloads = BulkDownloadResource(http_client=self._http_client)
+        return self._bulk_downloads
 
     @property
     def references(self) -> ReferenceResource:

--- a/src/gfwapiclient/resources/__init__.py
+++ b/src/gfwapiclient/resources/__init__.py
@@ -1,5 +1,6 @@
 """Global Fishing Watch (GFW) API Python Client - Resources."""
 
+from gfwapiclient.resources.bulk_downloads import BulkDownloadResource
 from gfwapiclient.resources.datasets import DatasetResource
 from gfwapiclient.resources.events import EventResource
 from gfwapiclient.resources.fourwings import FourWingsResource
@@ -9,6 +10,7 @@ from gfwapiclient.resources.vessels import VesselResource
 
 
 __all__ = [
+    "BulkDownloadResource",
     "DatasetResource",
     "EventResource",
     "FourWingsResource",

--- a/src/gfwapiclient/resources/bulk_downloads/__init__.py
+++ b/src/gfwapiclient/resources/bulk_downloads/__init__.py
@@ -19,3 +19,8 @@ Global Fishing Watch API documentation:
 
 See: https://globalfishingwatch.org/our-apis/documentation#sar-fixed-infrastructure-data-caveats
 """
+
+from gfwapiclient.resources.bulk_downloads.resources import BulkDownloadResource
+
+
+__all__ = ["BulkDownloadResource"]

--- a/src/gfwapiclient/resources/bulk_downloads/resources.py
+++ b/src/gfwapiclient/resources/bulk_downloads/resources.py
@@ -1,0 +1,433 @@
+"""Global Fishing Watch (GFW) API Python Client - Bulk Download API Resource."""
+
+from typing import Any, Dict, List, Optional, Union
+
+import pydantic
+
+from gfwapiclient.exceptions import (
+    RequestBodyValidationError,
+    RequestParamsValidationError,
+)
+from gfwapiclient.http.resources import BaseResource
+from gfwapiclient.resources.bulk_downloads.base.models.request import (
+    BulkReportDataset,
+    BulkReportFileType,
+    BulkReportFormat,
+    BulkReportGeometry,
+    BulkReportRegion,
+)
+from gfwapiclient.resources.bulk_downloads.base.models.response import BulkReportStatus
+from gfwapiclient.resources.bulk_downloads.create.endpoints import (
+    BulkReportCreateEndPoint,
+)
+from gfwapiclient.resources.bulk_downloads.create.models.request import (
+    BULK_REPORT_CREATE_BODY_VALIDATION_ERROR_MESSAGE,
+    BulkReportCreateBody,
+)
+from gfwapiclient.resources.bulk_downloads.create.models.response import (
+    BulkReportCreateResult,
+)
+from gfwapiclient.resources.bulk_downloads.detail.endpoints import (
+    BulkReportDetailEndPoint,
+)
+from gfwapiclient.resources.bulk_downloads.detail.models.response import (
+    BulkReportDetailResult,
+)
+from gfwapiclient.resources.bulk_downloads.file.endpoints import BulkReportFileEndPoint
+from gfwapiclient.resources.bulk_downloads.file.models.request import (
+    BULK_REPORT_FILE_PARAMS_VALIDATION_ERROR_MESSAGE,
+    BulkReportFileParams,
+)
+from gfwapiclient.resources.bulk_downloads.file.models.response import (
+    BulkReportFileResult,
+)
+from gfwapiclient.resources.bulk_downloads.list.endpoints import BulkReportListEndPoint
+from gfwapiclient.resources.bulk_downloads.list.models.request import (
+    BULK_REPORT_LIST_PARAMS_VALIDATION_ERROR_MESSAGE,
+    BulkReportListParams,
+)
+from gfwapiclient.resources.bulk_downloads.list.models.response import (
+    BulkReportListResult,
+)
+
+
+__all__ = ["BulkDownloadResource"]
+
+
+class BulkDownloadResource(BaseResource):
+    """Bulk download API resource.
+
+    This resource provides methods to interact with the Bulk Download API,
+    specifically to:
+
+    - Create bulk reports based on specific filters and spatial parameters.
+    - Monitor previously created bulk report generation status.
+    - Get signed URL to download previously created bulk report data, metadata and
+    region geometry (in GeoJSON format) files.
+    - Query previously created bulk report data records in JSON format.
+
+    For detailed information about the Bulk Download API, please refer to the official
+    Global Fishing Watch API documentation:
+
+    See: https://globalfishingwatch.org/our-apis/documentation#bulk-download-api
+
+    For more details on the Bulk Download API data caveats, please refer to the
+    official Global Fishing Watch API documentation:
+
+    See: https://globalfishingwatch.org/our-apis/documentation#sar-fixed-infrastructure-data-caveats
+    """
+
+    async def create_bulk_report(
+        self,
+        *,
+        name: str,
+        dataset: Optional[Union[BulkReportDataset, str]] = None,
+        geojson: Optional[Union[BulkReportGeometry, Dict[str, Any]]] = None,
+        format: Optional[Union[BulkReportFormat, str]] = None,
+        region: Optional[Union[BulkReportRegion, Dict[str, Any]]] = None,
+        filters: Optional[List[str]] = None,
+        **kwargs: Dict[str, Any],
+    ) -> BulkReportCreateResult:
+        """Create a bulk report based on specified filters and spatial parameters.
+
+        For detailed information about the Create a Bulk Report API endpoint, please
+        refer to the official Global Fishing Watch API documentation:
+
+        See: https://globalfishingwatch.org/our-apis/documentation#create-a-bulk-report
+
+        For more details on the Create a Bulk Report data caveats, please refer to the
+        official Global Fishing Watch API documentation:
+
+        See: https://globalfishingwatch.org/our-apis/documentation#sar-fixed-infrastructure-data-caveats
+
+        **Disclaimer:**
+
+        Depending on the complexity and size of your request (e.g., large geojson or region,
+        long date range etc), generating the bulk report can take several minutes to
+        several hours.
+
+        Attributes:
+            name (str):
+                Human-readable name of the bulk report.
+                Example: `"sar-fixed-infrastructure-data-20240903"`.
+
+            dataset (Optional[Union[BulkReportDataset, str]], default="public-fixed-infrastructure-data:latest"):
+                Dataset that will be used to create the bulk report.
+                Defaults to `"public-fixed-infrastructure-data:latest"`.
+                Allowed values: `"public-fixed-infrastructure-data:latest"`.
+                Example: `"public-fixed-infrastructure-data:latest"`.
+
+            geojson (Optional[Union[BulkReportGeometry, Dict[str, Any]]], default=None):
+                Custom GeoJSON geometry to filter the bulk report. Defaults to `None`.
+                Example: `{"type": "Polygon", "coordinates": [...]}`.
+
+            format (Optional[Union[BulkReportFormat, str]], default="JSON"):
+                Bulk report result format. Defaults to `"JSON"`.
+                Allowed values: `"JSON"`, `"CSV"`.
+                Example: `"JSON"`.
+
+            region (Optional[Union[BulkReportRegion, Dict[str, Any]]], default=None):
+                Predefined region information to filter the bulk report.
+                Defaults to `None`.
+                Example: `{"dataset": "public-eez-areas", "id": 8466}`.
+
+            filters (Optional[List[str]], default=None):
+                Filters to apply when generating the bulk report. Default to `None`.
+                Example: `["label = 'oil'"]`
+
+            **kwargs (Dict[str, Any]):
+                Additional keyword arguments.
+
+        Returns:
+            BulkReportCreateResult:
+                The created bulk report metadata and status.
+
+        Raises:
+            GFWAPIClientError:
+                If the API request fails.
+
+            RequestBodyValidationError:
+                If the request body is invalid.
+        """
+        request_body: BulkReportCreateBody = (
+            self._prepare_create_bulk_report_request_body(
+                name=name,
+                dataset=dataset,
+                geojson=geojson,
+                format=format,
+                region=region,
+                filters=filters,
+            )
+        )
+
+        endpoint: BulkReportCreateEndPoint = BulkReportCreateEndPoint(
+            request_body=request_body,
+            http_client=self._http_client,
+        )
+
+        result: BulkReportCreateResult = await endpoint.request()
+        return result
+
+    async def get_bulk_report_by_id(
+        self,
+        *,
+        id: str,
+        **kwargs: Dict[
+            str, Any
+        ],  # TODO: polling logics (throttled retry based on status)
+    ) -> BulkReportDetailResult:
+        """Get a bulk report by ID.
+
+        Retrieves metadata and status of the previously created bulk report based on the
+        provided bulk report ID.
+
+        For more details on the Get Bulk Report by ID API endpoint, please refer to the
+        official Global Fishing Watch API documentation:
+
+        See: https://globalfishingwatch.org/our-apis/documentation#get-bulk-report-by-id
+
+        For more details on the Get Bulk Report by ID data caveats, please refer
+        to the official Global Fishing Watch API documentation:
+
+        See: https://globalfishingwatch.org/our-apis/documentation#sar-fixed-infrastructure-data-caveats
+
+        **Important:**
+
+        We recommend to use this method to poll the status of previously created
+        bulk report, if it takes several minutes or hours to generate until it status
+        is `"done"` or `"failed"`.
+
+        Args:
+            id (str):
+                Unique identifier (ID) of the bulk report.
+                Example: `"adbb9b62-5c08-4142-82e0-b2b575f3e058"`
+
+            **kwargs (Dict[str, Any]):
+                Additional keyword arguments.
+
+        Returns:
+            BulkReportDetailResult:
+                The previously created bulk report metadata and status.
+
+        Raises:
+            GFWAPIClientError:
+                If the API request fails.
+        """
+        endpoint: BulkReportDetailEndPoint = BulkReportDetailEndPoint(
+            bulk_report_id=id, http_client=self._http_client
+        )
+
+        result: BulkReportDetailResult = await endpoint.request()
+        return result
+
+    async def get_all_bulk_reports(
+        self,
+        *,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        sort: Optional[str] = None,
+        status: Optional[Union[BulkReportStatus, str]] = None,
+        **kwargs: Dict[str, Any],
+    ) -> BulkReportListResult:
+        """Get all bulk reports created by user or application.
+
+        Retrieves a list of metadata and status of the previously created
+        bulk reports based on specified pagination, sorting, and filtering criteria.
+
+        For detailed information about the Get All Bulk Reports API endpoint, please
+        refer to the official Global Fishing Watch API documentation:
+
+        See: https://globalfishingwatch.org/our-apis/documentation#get-all-bulk-reports-by-user
+
+        For more details on the Get All Bulk Reports data caveats, please refer to the
+        official Global Fishing Watch API documentation:
+
+        See: https://globalfishingwatch.org/our-apis/documentation#sar-fixed-infrastructure-data-caveats
+
+        Args:
+            limit (Optional[int], default=99999):
+                Maximum number of bulk reports to return. Defaults to `99999`.
+                Example: `99999`.
+
+            offset (Optional[int], default=0):
+                Number of bulk reports to skip before returning results.
+                Defaults to `0`.
+                Example: `0`.
+
+            sort (Optional[str], default="-createdAt"):
+                Property to sort the bulk reports by. Defaults to `"-createdAt"`.
+                Example: `"-createdAt"`.
+
+            status (Optional[Union[BulkReportStatus, str]], default=None):
+                Current status of the bulk report generation process.
+                Defaults to `None`.
+                Allowed values: `"pending"`, `"processing"`, `"done"`, `"failed"`.
+                Example: `"done"`.
+
+            **kwargs (Dict[str, Any]):
+                Additional keyword arguments.
+
+        Returns:
+            BulkReportListResult:
+                The result containing the list of previously created bulk report
+                metadata and status.
+
+        Raises:
+            GFWAPIClientError:
+                If the API request fails.
+
+            RequestParamsValidationError:
+                If the request parameters are invalid.
+        """
+        request_params: BulkReportListParams = self._prepare_get_all_bulk_report_params(
+            limit=limit,
+            offset=offset,
+            sort=sort,
+            status=status,
+        )
+
+        endpoint: BulkReportListEndPoint = BulkReportListEndPoint(
+            request_params=request_params,
+            http_client=self._http_client,
+        )
+
+        result: BulkReportListResult = await endpoint.request()
+        return result
+
+    async def get_bulk_report_file_download_url(
+        self,
+        *,
+        id: str,
+        file: Optional[Union[BulkReportFileType, str]] = None,
+        **kwargs: Dict[str, Any],
+    ) -> BulkReportFileResult:
+        """Get signed URL to download file of the previously created bulk report.
+
+        Retrieves signed URL that points to a downloadable file hosted on Global Fishing
+        Watch's cloud infrastructure to download file(s) (i.e., `"DATA"`, `"README"`, or
+        `"GEOM"`) of the previously created bulk report.
+
+        For more details on the Download bulk Report (URL File) API endpoint, please
+        refer to the official Global Fishing Watch API documentation:
+
+        See: https://globalfishingwatch.org/our-apis/documentation#download-bulk-report-url-file
+
+        For more details on the Download bulk Report (URL File) data caveats, please
+        refer to the official Global Fishing Watch API documentation:
+
+        See: https://globalfishingwatch.org/our-apis/documentation#sar-fixed-infrastructure-data-caveats
+
+        Args:
+            id (str):
+                Unique identifier (ID) of the bulk report.
+                Example: `"adbb9b62-5c08-4142-82e0-b2b575f3e058"`.
+
+            file (Optional[Union[BulkReportFileType, str]], default="DATA"):
+                Type of bulk report file. Defaults to `"DATA"`.
+                Allowed values: `"DATA"`, `"README"`, `"GEOM"`.
+                Example: `"DATA"`
+
+            **kwargs (Dict[str, Any]):
+                Additional keyword arguments.
+
+        Returns:
+            BulkReportFileResult:
+                The signed URL to download bulk report file.
+
+        Raises:
+            GFWAPIClientError:
+                If the API request fails.
+
+            RequestParamsValidationError:
+                If the request parameters are invalid.
+        """
+        request_params: BulkReportFileParams = (
+            self._prepare_get_bulk_report_file_download_url_params(file=file)
+        )
+
+        endpoint: BulkReportFileEndPoint = BulkReportFileEndPoint(
+            bulk_report_id=id,
+            request_params=request_params,
+            http_client=self._http_client,
+        )
+
+        result: BulkReportFileResult = await endpoint.request()
+        return result
+
+    def _prepare_create_bulk_report_request_body(
+        self,
+        *,
+        name: str,
+        dataset: Optional[Union[BulkReportDataset, str]] = None,
+        geojson: Optional[Union[BulkReportGeometry, Dict[str, Any]]] = None,
+        format: Optional[Union[BulkReportFormat, str]] = None,
+        region: Optional[Union[BulkReportRegion, Dict[str, Any]]] = None,
+        filters: Optional[List[str]] = None,
+    ) -> BulkReportCreateBody:
+        """Prepare and return create a bulk report request body."""
+        try:
+            _dataset: Union[BulkReportDataset, str] = (
+                dataset or BulkReportDataset.FIXED_INFRASTRUCTURE_DATA_LATEST
+            )
+            _request_body: Dict[str, Any] = {
+                "name": name,  # TODO: generate based on dataset name and timestamp (YYYMMDDHHmmss) / uuidv4
+                "dataset": _dataset,
+                "geojson": geojson or None,
+                "format": format or BulkReportFormat.JSON,
+                "region": region or None,
+                "filters": filters or None,
+            }
+            request_body: BulkReportCreateBody = BulkReportCreateBody(**_request_body)
+        except pydantic.ValidationError as exc:
+            raise RequestBodyValidationError(
+                message=BULK_REPORT_CREATE_BODY_VALIDATION_ERROR_MESSAGE,
+                error=exc,
+            ) from exc
+
+        return request_body
+
+    def _prepare_get_all_bulk_report_params(
+        self,
+        *,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        sort: Optional[str] = None,
+        status: Optional[Union[BulkReportStatus, str]] = None,
+    ) -> BulkReportListParams:
+        """Prepare and return get all bulk report request parameters."""
+        try:
+            _request_params: Dict[str, Any] = {
+                "limit": limit or 99999,
+                "offset": offset or 0,
+                "sort": sort or "-createdAt",
+                "status": status or None,
+            }
+            request_params: BulkReportListParams = BulkReportListParams(
+                **_request_params
+            )
+        except pydantic.ValidationError as exc:
+            raise RequestParamsValidationError(
+                message=BULK_REPORT_LIST_PARAMS_VALIDATION_ERROR_MESSAGE,
+                error=exc,
+            ) from exc
+
+        return request_params
+
+    def _prepare_get_bulk_report_file_download_url_params(
+        self, *, file: Optional[Union[BulkReportFileType, str]] = None
+    ) -> BulkReportFileParams:
+        """Prepare and return get bulk report file download url request parameters."""
+        try:
+            _request_params: Dict[str, Any] = {
+                "file": file or BulkReportFileType.DATA,
+            }
+            request_params: BulkReportFileParams = BulkReportFileParams(
+                **_request_params
+            )
+        except pydantic.ValidationError as exc:
+            raise RequestParamsValidationError(
+                message=BULK_REPORT_FILE_PARAMS_VALIDATION_ERROR_MESSAGE,
+                error=exc,
+            ) from exc
+
+        return request_params

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -6,6 +6,7 @@ import pytest
 from gfwapiclient.client.client import GFW_API_BASE_URL, Client
 from gfwapiclient.exceptions.client import AccessTokenError
 from gfwapiclient.http.client import HTTPClient
+from gfwapiclient.resources.bulk_downloads.resources import BulkDownloadResource
 from gfwapiclient.resources.datasets.resources import DatasetResource
 from gfwapiclient.resources.events.resources import EventResource
 from gfwapiclient.resources.fourwings.resources import FourWingsResource
@@ -143,6 +144,17 @@ def test_client_datasets_property_returns_dataset_resource_and_is_cached(
     assert isinstance(client.datasets, DatasetResource)
     # Test that the property is cached
     assert client.datasets is client.datasets
+
+
+def test_client_bulk_downloads_property_returns_bulk_download_resource_and_is_cached(
+    mock_base_url: str,
+    mock_access_token: str,
+) -> None:
+    """Test `Client.bulk_downloads` returns `BulkDownloadResource` and caches the instance."""
+    client = Client()
+    assert isinstance(client.bulk_downloads, BulkDownloadResource)
+    # Test that the property is cached
+    assert client.bulk_downloads is client.bulk_downloads
 
 
 def test_client_references_property_returns_reference_resource_and_is_cached(

--- a/tests/resources/bulk_downloads/conftest.py
+++ b/tests/resources/bulk_downloads/conftest.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict, Final
 import pytest
 
 
+bulk_report_id: Final[str] = "adbb9b62-5c08-4142-82e0-b2b575f3e058"
 region_dataset: Final[str] = "public-eez-areas"
 region_id: Final[int] = 8466
 geometry: Final[Dict[str, Any]] = {

--- a/tests/resources/bulk_downloads/detail/test_endpoints.py
+++ b/tests/resources/bulk_downloads/detail/test_endpoints.py
@@ -1,6 +1,6 @@
 """Tests for `gfwapiclient.resources.bulk_downloads.detail.endpoints`."""
 
-from typing import Any, Dict, Final, cast
+from typing import Any, Dict, cast
 
 import httpx
 import pytest
@@ -16,8 +16,7 @@ from gfwapiclient.resources.bulk_downloads.detail.models.response import (
     BulkReportDetailResult,
 )
 
-
-bulk_report_id: Final[str] = "adbb9b62-5c08-4142-82e0-b2b575f3e058"
+from ..conftest import bulk_report_id
 
 
 @pytest.mark.asyncio

--- a/tests/resources/bulk_downloads/file/test_endpoints.py
+++ b/tests/resources/bulk_downloads/file/test_endpoints.py
@@ -1,6 +1,6 @@
 """Tests for `gfwapiclient.resources.bulk_downloads.file.endpoints`."""
 
-from typing import Any, Dict, Final, cast
+from typing import Any, Dict, cast
 
 import httpx
 import pytest
@@ -19,8 +19,7 @@ from gfwapiclient.resources.bulk_downloads.file.models.response import (
     BulkReportFileResult,
 )
 
-
-bulk_report_id: Final[str] = "adbb9b62-5c08-4142-82e0-b2b575f3e058"
+from ..conftest import bulk_report_id
 
 
 @pytest.mark.asyncio

--- a/tests/resources/bulk_downloads/test_resources.py
+++ b/tests/resources/bulk_downloads/test_resources.py
@@ -1,0 +1,176 @@
+"""Tests for `gfwapiclient.resources.bulk_downloads.resources`."""
+
+from typing import Any, Dict, List, cast
+
+import pytest
+import respx
+
+from gfwapiclient.exceptions.validation import (
+    RequestBodyValidationError,
+    RequestParamsValidationError,
+)
+from gfwapiclient.http.client import HTTPClient
+from gfwapiclient.resources.bulk_downloads.create.models.request import (
+    BULK_REPORT_CREATE_BODY_VALIDATION_ERROR_MESSAGE,
+)
+from gfwapiclient.resources.bulk_downloads.create.models.response import (
+    BulkReportCreateItem,
+    BulkReportCreateResult,
+)
+from gfwapiclient.resources.bulk_downloads.detail.models.response import (
+    BulkReportDetailItem,
+    BulkReportDetailResult,
+)
+from gfwapiclient.resources.bulk_downloads.file.models.request import (
+    BULK_REPORT_FILE_PARAMS_VALIDATION_ERROR_MESSAGE,
+)
+from gfwapiclient.resources.bulk_downloads.file.models.response import (
+    BulkReportFileItem,
+    BulkReportFileResult,
+)
+from gfwapiclient.resources.bulk_downloads.list.models.request import (
+    BULK_REPORT_LIST_PARAMS_VALIDATION_ERROR_MESSAGE,
+)
+from gfwapiclient.resources.bulk_downloads.list.models.response import (
+    BulkReportListItem,
+    BulkReportListResult,
+)
+from gfwapiclient.resources.bulk_downloads.resources import BulkDownloadResource
+
+from .conftest import bulk_report_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.respx
+async def test_bulk_download_resource_create_bulk_report_request_success(
+    mock_http_client: HTTPClient,
+    mock_raw_bulk_report_create_request_body: Dict[str, Any],
+    mock_raw_bulk_report_item: Dict[str, Any],
+    mock_responsex: respx.MockRouter,
+) -> None:
+    """Test `BulkDownloadResource`create bulk report succeeds with a valid response."""
+    mock_responsex.post("/bulk-reports").respond(201, json=mock_raw_bulk_report_item)
+    resource = BulkDownloadResource(http_client=mock_http_client)
+
+    result: BulkReportCreateResult = await resource.create_bulk_report(
+        **mock_raw_bulk_report_create_request_body
+    )
+    data = cast(BulkReportCreateItem, result.data())
+    assert isinstance(result, BulkReportCreateResult)
+    assert isinstance(data, BulkReportCreateItem)
+
+
+@pytest.mark.asyncio
+async def test_bulk_download_resource_create_bulk_report_request_body_validation_error_raises(
+    mock_http_client: HTTPClient,
+    mock_raw_bulk_report_create_request_body: Dict[str, Any],
+) -> None:
+    """Test `BulkDownloadResource`create bulk report raises `RequestBodyValidationError` with invalid bodies."""
+    resource = BulkDownloadResource(http_client=mock_http_client)
+
+    with pytest.raises(
+        RequestBodyValidationError,
+        match=BULK_REPORT_CREATE_BODY_VALIDATION_ERROR_MESSAGE,
+    ):
+        await resource.create_bulk_report(
+            **{
+                **mock_raw_bulk_report_create_request_body,
+                "dataset": "INVALID_DATASET",
+            }
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.respx
+async def test_bulk_download_resource_get_bulk_report_by_id_request_success(
+    mock_http_client: HTTPClient,
+    mock_raw_bulk_report_item: Dict[str, Any],
+    mock_responsex: respx.MockRouter,
+) -> None:
+    """Test `BulkDownloadResource` get bulk report by ID succeeds with a valid response."""
+    mock_responsex.get(f"/bulk-reports/{bulk_report_id}").respond(
+        200, json=mock_raw_bulk_report_item
+    )
+    resource = BulkDownloadResource(http_client=mock_http_client)
+
+    result: BulkReportDetailResult = await resource.get_bulk_report_by_id(
+        id=bulk_report_id,
+    )
+    data = cast(BulkReportDetailItem, result.data())
+    assert isinstance(result, BulkReportDetailResult)
+    assert isinstance(data, BulkReportDetailItem)
+
+
+@pytest.mark.asyncio
+@pytest.mark.respx
+async def test_bulk_download_resource_get_all_bulk_reports_request_success(
+    mock_http_client: HTTPClient,
+    mock_raw_bulk_report_list_request_params: Dict[str, Any],
+    mock_raw_bulk_report_item: Dict[str, Any],
+    mock_responsex: respx.MockRouter,
+) -> None:
+    """Test `BulkDownloadResource` get all bulk reports succeeds with a valid response."""
+    mock_responsex.get("/bulk-reports").respond(
+        200, json={"entries": [mock_raw_bulk_report_item, {}]}
+    )
+    resource = BulkDownloadResource(http_client=mock_http_client)
+    result: BulkReportListResult = await resource.get_all_bulk_reports(
+        **mock_raw_bulk_report_list_request_params
+    )
+    data = cast(List[BulkReportListItem], result.data())
+    assert isinstance(result, BulkReportListResult)
+    assert isinstance(data[0], BulkReportListItem)
+
+
+@pytest.mark.asyncio
+async def test_bulk_download_resource_get_all_bulk_reports_request_params_validation_error_raises(
+    mock_http_client: HTTPClient,
+) -> None:
+    """Test `BulkDownloadResource` get all bulk reports raises `RequestParamsValidationError` with invalid parameters."""
+    resource = BulkDownloadResource(http_client=mock_http_client)
+
+    with pytest.raises(
+        RequestParamsValidationError,
+        match=BULK_REPORT_LIST_PARAMS_VALIDATION_ERROR_MESSAGE,
+    ):
+        await resource.get_all_bulk_reports(limit=-1, offset=-1)
+
+
+@pytest.mark.asyncio
+@pytest.mark.respx
+async def test_bulk_download_resource_get_bulk_report_file_download_url_request_success(
+    mock_http_client: HTTPClient,
+    mock_raw_bulk_report_file_request_params: Dict[str, Any],
+    mock_raw_bulk_report_file_item: Dict[str, Any],
+    mock_responsex: respx.MockRouter,
+) -> None:
+    """Test `BulkDownloadResource` get bulk report file download url succeeds with a valid response."""
+    mock_responsex.get(f"bulk-reports/{bulk_report_id}/download-file-url").respond(
+        200, json=mock_raw_bulk_report_file_item
+    )
+    resource = BulkDownloadResource(http_client=mock_http_client)
+    result: BulkReportFileResult = await resource.get_bulk_report_file_download_url(
+        **{
+            **mock_raw_bulk_report_file_request_params,
+            "id": bulk_report_id,
+        }
+    )
+    data = cast(BulkReportFileItem, result.data())
+    assert isinstance(result, BulkReportFileResult)
+    assert isinstance(data, BulkReportFileItem)
+
+
+@pytest.mark.asyncio
+async def test_bulk_download_resource_get_bulk_report_file_download_url_request_params_validation_error_raises(
+    mock_http_client: HTTPClient,
+) -> None:
+    """Test `BulkDownloadResource` get bulk report file download url raises `RequestParamsValidationError` with invalid parameters."""
+    resource = BulkDownloadResource(http_client=mock_http_client)
+
+    with pytest.raises(
+        RequestParamsValidationError,
+        match=BULK_REPORT_FILE_PARAMS_VALIDATION_ERROR_MESSAGE,
+    ):
+        await resource.get_bulk_report_file_download_url(
+            id=bulk_report_id, file="INVALID_FILE_TYPE"
+        )


### PR DESCRIPTION
This:
- add `BulkDownloadResource` for high-level [Bulk Download API](https://globalfishingwatch.org/our-apis/documentation#bulk-download-api) interaction
- add `create_bulk_report` and `get_bulk_report_by_id` public methods
- add `get_all_bulk_reports` and `get_bulk_report_file_download_url` public methods
- expose the Bulk Download API via `Client.bulk_downloads`
- update `README` and `package docstrings` to include the Bulk Download API
- add `fixtures` and `unit tests` for `BulkDownloadResource`