### PR TITLE
add field filtering for EEZ, MPA, and RFMO reference region endpoints

### DIFF
--- a/src/gfwapiclient/resources/references/resources.py
+++ b/src/gfwapiclient/resources/references/resources.py
@@ -1,6 +1,8 @@
 """Global Fishing Watch (GFW) API Python Client - References Data API Resource."""
 
-from typing import Any, Dict
+import re
+
+from typing import Any, Callable, Dict, List, Optional, Pattern, Union, cast
 
 from gfwapiclient.http.resources import BaseResource
 from gfwapiclient.resources.references.regions.endpoints import (
@@ -9,8 +11,11 @@ from gfwapiclient.resources.references.regions.endpoints import (
     RFMORegionEndPoint,
 )
 from gfwapiclient.resources.references.regions.models.response import (
+    EEZRegionItem,
     EEZRegionResult,
+    MPARegionItem,
     MPARegionResult,
+    RFMORegionItem,
     RFMORegionResult,
 )
 
@@ -53,7 +58,27 @@ class ReferenceResource(BaseResource):
     See: https://globalfishingwatch.org/our-apis/documentation#marine-protected-area-boundaries-definition-2
     """
 
-    async def get_eez_regions(self, **kwargs: Dict[str, Any]) -> EEZRegionResult:
+    async def get_eez_regions(
+        self,
+        *,
+        id: Optional[Union[str, Pattern[str], List[str], List[Pattern[str]]]] = None,
+        label: Optional[Union[str, Pattern[str], List[str], List[Pattern[str]]]] = None,
+        iso3: Optional[Union[str, Pattern[str], List[str], List[Pattern[str]]]] = None,
+        iso_sov_1: Optional[
+            Union[str, Pattern[str], List[str], List[Pattern[str]]]
+        ] = None,
+        iso_sov_2: Optional[
+            Union[str, Pattern[str], List[str], List[Pattern[str]]]
+        ] = None,
+        iso_sov_3: Optional[
+            Union[str, Pattern[str], List[str], List[Pattern[str]]]
+        ] = None,
+        territory_1: Optional[
+            Union[str, Pattern[str], List[str], List[Pattern[str]]]
+        ] = None,
+        predicate: Optional[Callable[[EEZRegionItem], bool]] = None,
+        **kwargs: Dict[str, Any],
+    ) -> EEZRegionResult:
         """Get available Exclusive Economic Zone (EEZ) regions data.
 
         Retrieves a list of Exclusive Economic Zone (EEZ) regions.
@@ -73,6 +98,39 @@ class ReferenceResource(BaseResource):
         See: https://globalfishingwatch.org/our-apis/documentation#exclusive-economic-zone-boundaries-definitions
 
         Args:
+            id (Optional[Union[str, Pattern[str], List[str], List[Pattern[str]]]], default=None):
+                Filter(s) to apply to the unique identifier (id). Defaults to `None`.
+                Example: `id="8371"`.
+
+            label (Optional[Union[str, Pattern[str], List[str], List[Pattern[str]]]], default=None):
+                Filter(s) to apply to the label (name). Defaults to `None`.
+                Example: `label="Senegalese"`.
+
+            iso3 (Optional[Union[str, Pattern[str], List[str], List[Pattern[str]]]], default=None):
+                Filter(s) to apply to the ISO 3166-1 alpha-3 country code.
+                Defaults to `None`.
+                Example: `iso3="SEN"`.
+
+            iso_sov_1 (Optional[Union[str, Pattern[str], List[str], List[Pattern[str]]]], default=None):
+                Filter(s) to apply to the primary sovereignty ISO code.
+                Defaults to `None`.
+
+            iso_sov_2 (Optional[Union[str, Pattern[str], List[str], List[Pattern[str]]]], default=None):
+                Filter(s) to apply to the secondary sovereignty ISO code.
+                Defaults to `None`.
+
+            iso_sov_3 (Optional[Union[str, Pattern[str], List[str], List[Pattern[str]]]], default=None):
+                Filter(s) to apply to the tertiary sovereignty ISO code.
+                Defaults to `None`.
+
+            territory_1 (Optional[Union[str, Pattern[str], List[str], List[Pattern[str]]]], default=None):
+                Filter(s) to apply to the territory name. Defaults to `None`.
+                Example: `territory_1="Senegal"`.
+
+            predicate (Optional[Callable[[EEZRegionItem], bool]], default=None):
+                An optional callable that accepts a `EEZRegionItem` instance and
+                returns `True` if it should be included.
+
             **kwargs (Dict[str, Any]):
                 Additional keyword arguments to pass to the EEZ region endpoint's request.
 
@@ -86,9 +144,42 @@ class ReferenceResource(BaseResource):
         """
         endpoint: EEZRegionEndPoint = EEZRegionEndPoint(http_client=self._http_client)
         result: EEZRegionResult = await endpoint.request(**kwargs)
+
+        # Filter result by field filters
+        item_filters: Dict[
+            str, Union[str, Pattern[str], List[str], List[Pattern[str]]]
+        ] = {
+            k: v
+            for k, v in {
+                "id": id,
+                "iso3": iso3,
+                "label": label,
+                "iso_sov_1": iso_sov_1,
+                "iso_sov_2": iso_sov_2,
+                "iso_sov_3": iso_sov_3,
+                "territory_1": territory_1,
+            }.items()
+            if v
+        }
+        field_filters_predicate: Callable[[EEZRegionItem], bool] = (
+            self._build_field_filters_predicate(item_filters=item_filters)
+        )
+        result = cast(EEZRegionResult, result.filter(predicate=field_filters_predicate))
+
+        # Filter result by custom predicate
+        if predicate and callable(predicate):
+            result = cast(EEZRegionResult, result.filter(predicate=predicate))
+
         return result
 
-    async def get_mpa_regions(self, **kwargs: Dict[str, Any]) -> MPARegionResult:
+    async def get_mpa_regions(
+        self,
+        *,
+        id: Optional[Union[str, Pattern[str], List[str], List[Pattern[str]]]] = None,
+        label: Optional[Union[str, Pattern[str], List[str], List[Pattern[str]]]] = None,
+        predicate: Optional[Callable[[MPARegionItem], bool]] = None,
+        **kwargs: Dict[str, Any],
+    ) -> MPARegionResult:
         """Get available Marine Protected Area (MPA) regions data.
 
         Retrieves a list of Marine Protected Area (MPA) regions.
@@ -108,6 +199,18 @@ class ReferenceResource(BaseResource):
         See: https://globalfishingwatch.org/our-apis/documentation#marine-protected-area-boundaries-definition-2
 
         Args:
+            id (Optional[Union[str, Pattern[str], List[str], List[Pattern[str]]]], default=None):
+                Filter(s) to apply to the unique identifier (id). Defaults to `None`.
+                Example: `id="555745302"`.
+
+            label (Optional[Union[str, Pattern[str], List[str], List[Pattern[str]]]], default=None):
+                Filter(s) to apply to the label (name). Defaults to `None`.
+                Example: `label="Dorsal de Nasca"`.
+
+            predicate (Optional[Callable[[MPARegionItem], bool]], default=None):
+                An optional callable that accepts a `MPARegionItem` instance and
+                returns `True` if it should be included.
+
             **kwargs (Dict[str, Any]):
                 Additional keyword arguments to pass to the MPA region endpoint's request.
 
@@ -121,9 +224,30 @@ class ReferenceResource(BaseResource):
         """
         endpoint: MPARegionEndPoint = MPARegionEndPoint(http_client=self._http_client)
         result: MPARegionResult = await endpoint.request(**kwargs)
+
+        # Filter result by field filters
+        item_filters: Dict[
+            str, Union[str, Pattern[str], List[str], List[Pattern[str]]]
+        ] = {k: v for k, v in {"id": id, "label": label}.items() if v}
+        field_filters_predicate: Callable[[MPARegionItem], bool] = (
+            self._build_field_filters_predicate(item_filters=item_filters)
+        )
+        result = cast(MPARegionResult, result.filter(predicate=field_filters_predicate))
+
+        # Filter result by custom predicate
+        if predicate and callable(predicate):
+            result = cast(MPARegionResult, result.filter(predicate=predicate))
+
         return result
 
-    async def get_rfmo_regions(self, **kwargs: Dict[str, Any]) -> RFMORegionResult:
+    async def get_rfmo_regions(
+        self,
+        *,
+        id: Optional[Union[str, Pattern[str], List[str], List[Pattern[str]]]] = None,
+        label: Optional[Union[str, Pattern[str], List[str], List[Pattern[str]]]] = None,
+        predicate: Optional[Callable[[RFMORegionItem], bool]] = None,
+        **kwargs: Dict[str, Any],
+    ) -> RFMORegionResult:
         """Get available Regional Fisheries Management Organization (RFMO) regions data.
 
         Retrieves a list of Regional Fisheries Management Organization (RFMO) regions.
@@ -143,6 +267,18 @@ class ReferenceResource(BaseResource):
         See: https://globalfishingwatch.org/our-apis/documentation#insights-api-rfmo-iuu-vessel-list
 
         Args:
+            id (Optional[Union[str, Pattern[str], List[str], List[Pattern[str]]]], default=None):
+                Filter(s) to apply to the unique identifier (id). Defaults to `None`.
+                Example: `id="ICCAT"`.
+
+            label (Optional[Union[str, Pattern[str], List[str], List[Pattern[str]]]], default=None):
+                Filter(s) to apply to the label (name). Defaults to `None`.
+                Example: `label="ICCAT"`.
+
+            predicate (Optional[Callable[[RFMORegionItem], bool]], default=None):
+                An optional callable that accepts a `RFMORegionItem` instance and
+                returns `True` if it should be included.
+
             **kwargs (Dict[str, Any]):
                 Additional keyword arguments to pass to the RFMO region endpoint's request.
 
@@ -156,4 +292,129 @@ class ReferenceResource(BaseResource):
         """
         endpoint: RFMORegionEndPoint = RFMORegionEndPoint(http_client=self._http_client)
         result: RFMORegionResult = await endpoint.request(**kwargs)
+
+        # Filter result by field filters
+        item_filters: Dict[
+            str, Union[str, Pattern[str], List[str], List[Pattern[str]]]
+        ] = {k: v for k, v in {"id": id, "label": label}.items() if v}
+        field_filters_predicate: Callable[[RFMORegionItem], bool] = (
+            self._build_field_filters_predicate(item_filters=item_filters)
+        )
+        result = cast(
+            RFMORegionResult, result.filter(predicate=field_filters_predicate)
+        )
+
+        # Filter result by custom predicate
+        if predicate and callable(predicate):
+            result = cast(RFMORegionResult, result.filter(predicate=predicate))
+
         return result
+
+    def _build_field_filters_predicate(
+        self,
+        *,
+        item_filters: Dict[
+            str, Union[str, Pattern[str], List[str], List[Pattern[str]]]
+        ],
+    ) -> Callable[[Union[EEZRegionItem, MPARegionItem, RFMORegionItem]], bool]:
+        """Build a predicate that filters region items by field values.
+
+        All provided field filters must match (logical AND).
+
+        Args:
+            item_filters (Dict[str, Union[str, Pattern[str], List[str], List[Pattern[str]]]]):
+                Mapping of item field names to filter values.
+
+        Returns:
+            Callable[[Union[EEZRegionItem, MPARegionItem, RFMORegionItem]], bool]:
+                Predicate suitable to filter region `ResultItem` by fields.
+        """
+
+        def predicate(
+            item: Union[EEZRegionItem, MPARegionItem, RFMORegionItem],
+        ) -> bool:
+            return all(
+                self._match_field_filters(
+                    field_value=cast(Optional[str], getattr(item, field_name, None)),
+                    field_filters=field_filters,
+                )
+                for field_name, field_filters in item_filters.items()
+            )
+
+        return predicate
+
+    def _match_field_filters(
+        self,
+        *,
+        field_value: Optional[str] = None,
+        field_filters: Optional[
+            Union[str, Pattern[str], List[str], List[Pattern[str]]]
+        ] = None,
+    ) -> bool:
+        """Check whether a field value matches any of the provided field filters.
+
+        Matching is case-insensitive and regex-based.
+
+        Args:
+            field_value (Optional[str]):
+                Field value to be matched.
+
+            field_filters (Optional[Union[str, Pattern[str], List[str], List[Pattern[str]]]]):
+                Field filters to match against field value.
+
+        Returns:
+            bool:
+                `True` if any field filter matches the field value, otherwise `False`.
+        """
+        if not field_value or not field_filters:
+            return False
+
+        _field_filters: List[Pattern[str]] = self._normalize_field_filter(
+            field_filter=field_filters
+        )
+
+        return any(
+            True if field_filter.search(field_value) else False
+            for field_filter in _field_filters
+        )
+
+    def _normalize_field_filter(
+        self,
+        *,
+        field_filter: Optional[
+            Union[str, Pattern[str], List[str], List[Pattern[str]]]
+        ] = None,
+    ) -> List[Pattern[str]]:
+        """Normalize field filter into a list of compiled regex patterns.
+
+        - Strings are stripped and compiled as case-insensitive regex.
+        - Regex patterns are preserved.
+        - Empty or invalid values are discarded.
+
+        Args:
+            field_filter (Optional[Union[str, Pattern[str], List[str], List[Pattern[str]]]]):
+                Raw field filter(s).
+
+        Returns:
+            List[Pattern[str]]:
+                Normalized list of field filter(s).
+        """
+        if not field_filter:
+            return []
+
+        # Normalize field filter to list
+        field_filters: List[Union[str, Pattern[str]]] = (
+            [*field_filter] if isinstance(field_filter, list) else [field_filter]
+        )
+        field_filters = [
+            v.strip() if isinstance(v, str) else v for v in field_filters if v
+        ]
+        field_filters = [
+            v for v in field_filters if v and isinstance(v, (str, re.Pattern))
+        ]
+
+        # Normalize field filter to list of compiled regex patterns
+        _field_filters: List[Pattern[str]] = [
+            re.compile(v, re.I) if isinstance(v, str) else v for v in field_filters
+        ]
+        return _field_filters

--- a/tests/resources/references/test_resources.py
+++ b/tests/resources/references/test_resources.py
@@ -1,6 +1,8 @@
 """Tests for `gfwapiclient.resources.references.resources`."""
 
-from typing import Any, Dict, List, cast
+import re
+
+from typing import Any, Callable, Dict, List, Optional, Pattern, Union, cast
 
 import pytest
 import respx
@@ -36,6 +38,51 @@ async def test_reference_resource_get_eez_regions_success(
     assert isinstance(data[0], EEZRegionItem)
 
 
+@pytest.mark.parametrize(
+    "item_filters,matched_id,matched_size",
+    [
+        ({}, "8371", 1),
+        ({"id": "8371"}, "8371", 1),
+        ({"label": "Senegalese"}, "8371", 1),
+        ({"iso3": "SEN"}, "8371", 1),
+        ({"predicate": lambda item: item.id == "8371"}, "8371", 1),
+        ({"id": " "}, None, 0),
+        ({"id": "INVALID_VALUE"}, None, 0),
+    ],
+)
+@pytest.mark.asyncio
+@pytest.mark.respx
+async def test_reference_resource_get_eez_regions_filter_success(
+    mock_http_client: HTTPClient,
+    mock_raw_eez_region_item: Dict[str, Any],
+    mock_responsex: respx.MockRouter,
+    item_filters: Dict[
+        str,
+        Union[
+            str,
+            Pattern[str],
+            List[str],
+            List[Pattern[str]],
+            Callable[[EEZRegionItem], bool],
+        ],
+    ],
+    matched_id: Optional[str],
+    matched_size: int,
+) -> None:
+    """Test `ReferenceResource` get filtered eez regions succeeds with valid response."""
+    mock_responsex.get("/datasets/public-eez-areas/context-layers").respond(
+        200, json=[mock_raw_eez_region_item]
+    )
+    resource = ReferenceResource(http_client=mock_http_client)
+    result = await resource.get_eez_regions(**item_filters)  # type: ignore[arg-type]
+    data = cast(List[EEZRegionItem], result.data())
+    assert isinstance(result, EEZRegionResult)
+    assert len(data) == matched_size
+    if matched_size >= 1:
+        assert isinstance(data[0], EEZRegionItem)
+        assert data[0].id == matched_id
+
+
 @pytest.mark.asyncio
 @pytest.mark.respx
 async def test_reference_resource_get_mpa_regions_success(
@@ -55,6 +102,50 @@ async def test_reference_resource_get_mpa_regions_success(
     assert isinstance(data[0], MPARegionItem)
 
 
+@pytest.mark.parametrize(
+    "item_filters,matched_id,matched_size",
+    [
+        ({}, "555745302", 1),
+        ({"id": "555745302"}, "555745302", 1),
+        ({"label": "Dorsal de Nasca"}, "555745302", 1),
+        ({"predicate": lambda item: item.id == "555745302"}, "555745302", 1),
+        ({"id": " "}, None, 0),
+        ({"id": "INVALID_VALUE"}, None, 0),
+    ],
+)
+@pytest.mark.asyncio
+@pytest.mark.respx
+async def test_reference_resource_get_mpa_regions_filter_success(
+    mock_http_client: HTTPClient,
+    mock_raw_mpa_region_item: Dict[str, Any],
+    mock_responsex: respx.MockRouter,
+    item_filters: Dict[
+        str,
+        Union[
+            str,
+            Pattern[str],
+            List[str],
+            List[Pattern[str]],
+            Callable[[MPARegionItem], bool],
+        ],
+    ],
+    matched_id: Optional[str],
+    matched_size: int,
+) -> None:
+    """Test `ReferenceResource` get filtered mpa regions succeeds with valid response."""
+    mock_responsex.get("/datasets/public-mpa-all/context-layers").respond(
+        200, json=[mock_raw_mpa_region_item]
+    )
+    resource = ReferenceResource(http_client=mock_http_client)
+    result = await resource.get_mpa_regions(**item_filters)  # type: ignore[arg-type]
+    data = cast(List[MPARegionItem], result.data())
+    assert isinstance(result, MPARegionResult)
+    assert len(data) == matched_size
+    if matched_size >= 1:
+        assert isinstance(data[0], MPARegionItem)
+        assert data[0].id == matched_id
+
+
 @pytest.mark.asyncio
 @pytest.mark.respx
 async def test_reference_resource_get_rfmo_regions_success(
@@ -72,3 +163,137 @@ async def test_reference_resource_get_rfmo_regions_success(
     assert isinstance(result, RFMORegionResult)
     assert len(data) == 1
     assert isinstance(data[0], RFMORegionItem)
+
+
+@pytest.mark.parametrize(
+    "item_filters,matched_id,matched_size",
+    [
+        ({}, "ICCAT", 1),
+        ({"id": "ICCAT"}, "ICCAT", 1),
+        ({"label": "ICCAT"}, "ICCAT", 1),
+        ({"predicate": lambda item: item.id == "ICCAT"}, "ICCAT", 1),
+        ({"id": " "}, None, 0),
+        ({"id": "INVALID_VALUE"}, None, 0),
+    ],
+)
+@pytest.mark.asyncio
+@pytest.mark.respx
+async def test_reference_resource_get_rfmo_regions_filter_success(
+    mock_http_client: HTTPClient,
+    mock_raw_rfmo_region_item: Dict[str, Any],
+    mock_responsex: respx.MockRouter,
+    item_filters: Dict[
+        str,
+        Union[
+            str,
+            Pattern[str],
+            List[str],
+            List[Pattern[str]],
+            Callable[[RFMORegionItem], bool],
+        ],
+    ],
+    matched_id: Optional[str],
+    matched_size: int,
+) -> None:
+    """Test `ReferenceResource` get filtered rfmo regions succeeds with valid response."""
+    mock_responsex.get("/datasets/public-rfmo/context-layers").respond(
+        200, json=[mock_raw_rfmo_region_item]
+    )
+    resource = ReferenceResource(http_client=mock_http_client)
+    result = await resource.get_rfmo_regions(**item_filters)  # type: ignore[arg-type]
+    data = cast(List[RFMORegionItem], result.data())
+    assert isinstance(result, RFMORegionResult)
+    assert len(data) == matched_size
+    if matched_size >= 1:
+        assert isinstance(data[0], RFMORegionItem)
+        assert data[0].id == matched_id
+
+
+@pytest.mark.parametrize(
+    "item_filters,expected_match",
+    [
+        ({"id": "8371"}, True),
+        ({"iso3": "SEN"}, True),
+        ({"label": "Senegalese"}, True),
+        ({"territory_1": "Senegal"}, True),
+        ({"label": re.compile("senegal", re.I)}, True),
+        ({"id": "8371", "iso3": "SEN"}, True),
+        ({"id": "INVALID_VALUE"}, False),
+        ({"iso3": "INVALID_VALUE"}, False),
+        ({"id": "8371", "iso3": "INVALID_VALUE"}, False),
+        ({"id": None}, False),
+        ({"id": None, "iso3": None}, False),
+        ({}, True),
+    ],
+)
+def test_build_field_filters_predicate_correctly(
+    mock_http_client: HTTPClient,
+    mock_raw_eez_region_item: Dict[str, Any],
+    item_filters: Dict[str, Union[str, Pattern[str], List[str], List[Pattern[str]]]],
+    expected_match: bool,
+) -> None:
+    """Test that `ReferenceResource` build field filters predicate correctly."""
+    resource = ReferenceResource(http_client=mock_http_client)
+    region = EEZRegionItem(**mock_raw_eez_region_item)
+    field_filters_predicate = resource._build_field_filters_predicate(
+        item_filters=item_filters
+    )
+
+    assert field_filters_predicate(region) == expected_match
+
+
+@pytest.mark.parametrize(
+    "field_value,field_filters,expected_match",
+    [
+        ("SEN", "SEN", True),
+        (" SEN ", ["SEN"], True),
+        ("SEN", re.compile("SEN", re.I), True),
+        ("SEN", [re.compile("SEN", re.I)], True),
+        ("Senegalese", "SEN", True),
+        ("SEN", ["INVALID_VALUE"], False),
+        ("SEN", None, False),
+        (None, ["SEN"], False),
+        (None, [], False),
+        (None, None, False),
+    ],
+)
+def test_match_field_filters_correctly(
+    mock_http_client: HTTPClient,
+    field_value: Optional[str],
+    field_filters: Union[str, Pattern[str], List[str], List[Pattern[str]]],
+    expected_match: bool,
+) -> None:
+    """Test that `ReferenceResource` match field filters correctly."""
+    resource = ReferenceResource(http_client=mock_http_client)
+    match = resource._match_field_filters(
+        field_value=field_value, field_filters=field_filters
+    )
+
+    assert match == expected_match
+
+
+@pytest.mark.parametrize(
+    "field_filter,expected_field_filters",
+    [
+        ("SEN", [re.compile("SEN", re.I)]),
+        (["SEN"], [re.compile("SEN", re.I)]),
+        (" SEN ", [re.compile("SEN", re.I)]),
+        (re.compile("SEN", re.I), [re.compile("SEN", re.I)]),
+        ([re.compile("SEN", re.I)], [re.compile("SEN", re.I)]),
+        (None, []),
+        (" ", []),
+        ([None], []),
+        ([" "], []),
+    ],
+)
+def test_normalize_field_filter_correctly(
+    mock_http_client: HTTPClient,
+    field_filter: Union[str, Pattern[str], List[str], List[Pattern[str]]],
+    expected_field_filters: List[Union[str, Pattern[str]]],
+) -> None:
+    """Test that `ReferenceResource` normalize field filter correctly."""
+    resource = ReferenceResource(http_client=mock_http_client)
+    field_filters = resource._normalize_field_filter(field_filter=field_filter)
+
+    assert field_filters == expected_field_filters
+    assert all(isinstance(field_filter, re.Pattern) for field_filter in field_filters)


### PR DESCRIPTION
This:
- Add regex, string, and list-based field filters to `EEZ`, `MPA`, and `RFMO` regions
- Support filtering by identifiers, labels, ISO codes, sovereignty, and territory fields (EEZ)
- Add unit tests for filtering logics and edge cases