### PR TITLE
add Conda installation guides and setup documentation

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -7,7 +7,7 @@ This guide provides detailed instructions for installing the [gfw-api-python-cli
 Before you begin, ensure you have the following installed on your system:
 
 - **Python** >= 3.11 ([Download Python](https://www.python.org/downloads/))
-- **pip** >= 25 ([Upgrade pip](https://pip.pypa.io/en/stable/installation/)), or **conda** >= 26 ([Installing conda](https://docs.conda.io/projects/conda/en/latest/index.html) - [Miniforge](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html#term-Miniforge) distribution is recommended)
+- **pip** >= 25 ([Upgrade pip](https://pip.pypa.io/en/stable/installation/)), or **Conda** >= 26 ([Installing Conda](https://docs.conda.io/projects/conda/en/latest/index.html) - [Miniforge](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html#term-Miniforge) distribution is recommended)
 - **Virtual Environment Tool** ([venv](https://docs.python.org/3/library/venv.html))
 
 ## Creating and Activating a Virtual Environment
@@ -56,9 +56,9 @@ Your terminal prompt should now be prefixed with `(.venv)`, indicating that the 
 
 Your terminal prompt should now be prefixed with `(.venv)`, indicating that the virtual environment is active.
 
-### Using conda
+### Using Conda
 
-If you use conda ([Miniforge](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html#term-Miniforge) distribution is recommended), create and activate a dedicated environment before installing the package:
+If you use [Conda](https://conda.io/en/latest/) ([Miniforge](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html#term-Miniforge) distribution is recommended), create and activate a dedicated environment before installing the package:
 
 ```bash
 conda create -n gfw python=3.11
@@ -84,9 +84,9 @@ pip install gfw-api-python-client
 
 `pip` will automatically download and install the `gfw-api-python-client` and its required dependencies.
 
-### Installing from conda (`conda-forge`)
+### Installing from Conda (`conda-forge`)
 
-This method installs the stable, pre-packaged version of the `gfw-api-python-client` from the [conda](https://anaconda.org/conda-forge/gfw-api-python-client).
+This method installs the stable, pre-packaged version of the `gfw-api-python-client` from the [Conda](https://anaconda.org/conda-forge/gfw-api-python-client) package manager.
 
 ```bash
 conda install -c conda-forge gfw-api-python-client
@@ -123,9 +123,9 @@ To upgrade an existing installation to the latest version available on PyPI:
 python -m pip install --upgrade gfw-api-python-client
 ```
 
-### Updating a conda (`conda-forge`) Installation
+### Updating a Conda (`conda-forge`) Installation
 
-To upgrade an existing installation to the latest version available on conda:
+To upgrade an existing installation to the latest version available on Conda:
 
 ```bash
 conda update -c conda-forge gfw-api-python-client

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -7,14 +7,20 @@ This guide provides detailed instructions for installing the [gfw-api-python-cli
 Before you begin, ensure you have the following installed on your system:
 
 - **Python** >= 3.11 ([Download Python](https://www.python.org/downloads/))
-- **pip** >= 25 ([Upgrade pip](https://pip.pypa.io/en/stable/installation/))
+- **pip** >= 25 ([Upgrade pip](https://pip.pypa.io/en/stable/installation/)), or **conda** >= 26 ([Installing conda](https://docs.conda.io/projects/conda/en/latest/index.html) - [Miniforge](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html#term-Miniforge) distribution is recommended)
 - **Virtual Environment Tool** ([venv](https://docs.python.org/3/library/venv.html))
 
 ## Creating and Activating a Virtual Environment
 
 Using a virtual environment helps avoid conflicts with other Python projects and ensures that the dependencies for the `gfw-api-python-client` are managed separately.
 
-### On macOS and Linux
+### Using `venv` (pip users)
+
+The built-in
+[`venv`](https://docs.python.org/3/library/venv.html)
+module is the recommended option when installing the package with `pip`.
+
+#### On macOS and Linux
 
 - Open your terminal and navigate to the directory where you want to create your project.
 
@@ -32,7 +38,7 @@ Using a virtual environment helps avoid conflicts with other Python projects and
 
 Your terminal prompt should now be prefixed with `(.venv)`, indicating that the virtual environment is active.
 
-### On Windows
+#### On Windows
 
 - Open Command Prompt or PowerShell and navigate to the directory where you want to create your project.
 
@@ -50,6 +56,20 @@ Your terminal prompt should now be prefixed with `(.venv)`, indicating that the 
 
 Your terminal prompt should now be prefixed with `(.venv)`, indicating that the virtual environment is active.
 
+### Using conda
+
+If you use conda ([Miniforge](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html#term-Miniforge) distribution is recommended), create and activate a dedicated environment before installing the package:
+
+```bash
+conda create -n gfw python=3.11
+conda activate gfw
+
+conda config --add channels conda-forge
+conda config --set channel_priority strict
+```
+
+Your terminal prompt should now be prefixed with `(gfw)`, indicating that the virtual environment is active.
+
 ## Installation Methods
 
 Choose one of the following methods to install the `gfw-api-python-client`.
@@ -63,6 +83,16 @@ pip install gfw-api-python-client
 ```
 
 `pip` will automatically download and install the `gfw-api-python-client` and its required dependencies.
+
+### Installing from conda (`conda-forge`)
+
+This method installs the stable, pre-packaged version of the `gfw-api-python-client` from the [conda](https://anaconda.org/conda-forge/gfw-api-python-client).
+
+```bash
+conda install -c conda-forge gfw-api-python-client
+```
+
+`conda` will automatically download and install the `gfw-api-python-client` and its required dependencies.
 
 ### Installing from Source
 
@@ -91,6 +121,14 @@ To upgrade an existing installation to the latest version available on PyPI:
 
 ```bash
 python -m pip install --upgrade gfw-api-python-client
+```
+
+### Updating a conda (`conda-forge`) Installation
+
+To upgrade an existing installation to the latest version available on conda:
+
+```bash
+conda update -c conda-forge gfw-api-python-client
 ```
 
 ### Updating an Installation from Source

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The Global Fishing Watch Python package currently works with the following APIs:
 ## Requirements
 
 - [Python >= 3.11](https://www.python.org/downloads/)
-- [pip >= 25](https://pip.pypa.io/en/stable/installation/), or [conda >= 26](https://docs.conda.io/projects/conda/en/latest/index.html) - [Miniforge](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html#term-Miniforge) distribution is recommended
+- [pip >= 25](https://pip.pypa.io/en/stable/installation/), or [Conda >= 26](https://docs.conda.io/projects/conda/en/latest/index.html) - [Miniforge](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html#term-Miniforge) distribution is recommended
 - [venv - Python's built-in virtual environment tool](https://docs.python.org/3/library/venv.html)
 - [API access token from the Global Fishing Watch API portal](https://globalfishingwatch.org/our-apis/tokens)
 
@@ -57,7 +57,7 @@ The Global Fishing Watch Python package currently works with the following APIs:
 
 The latest release of `gfw-api-python-client` is available from both the
 [Python Package Index (PyPI)](https://pypi.org/project/gfw-api-python-client/)
-and [conda-forge](https://anaconda.org/conda-forge/gfw-api-python-client).
+and [Conda](https://anaconda.org/conda-forge/gfw-api-python-client).
 
 Install the latest release from [PyPI](https://pypi.org/project/gfw-api-python-client/):
 
@@ -65,7 +65,7 @@ Install the latest release from [PyPI](https://pypi.org/project/gfw-api-python-c
 pip install gfw-api-python-client
 ```
 
-Install the latest release from [conda-forge](https://anaconda.org/conda-forge/gfw-api-python-client):
+Install the latest release from [Conda](https://anaconda.org/conda-forge/gfw-api-python-client):
 
 ```bash
 conda install -c conda-forge gfw-api-python-client

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![ci](https://github.com/GlobalFishingWatch/gfw-api-python-client/actions/workflows/ci.yaml/badge.svg)](https://github.com/GlobalFishingWatch/gfw-api-python-client/actions/workflows/ci.yaml)
 [![codecov](https://codecov.io/gh/GlobalFishingWatch/gfw-api-python-client/branch/develop/graph/badge.svg?token=w4R4VZB5RY)](https://codecov.io/gh/GlobalFishingWatch/gfw-api-python-client)
 [![pypi - version](https://img.shields.io/pypi/v/gfw-api-python-client)](https://pypi.org/project/gfw-api-python-client/)
+[![conda - version](https://anaconda.org/conda-forge/gfw-api-python-client/badges/version.svg)](https://anaconda.org/conda-forge/gfw-api-python-client)
 [![pypi - python versions](https://img.shields.io/pypi/pyversions/gfw-api-python-client)](https://pypi.org/project/gfw-api-python-client/)
 [![license](https://img.shields.io/badge/license-Apache%202-blue)](https://github.com/GlobalFishingWatch/gfw-api-python-client/blob/main/LICENSE)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15617432.svg)](https://doi.org/10.5281/zenodo.15617432)
@@ -48,16 +49,26 @@ The Global Fishing Watch Python package currently works with the following APIs:
 ## Requirements
 
 - [Python >= 3.11](https://www.python.org/downloads/)
-- [pip >= 25](https://pip.pypa.io/en/stable/installation/)
+- [pip >= 25](https://pip.pypa.io/en/stable/installation/), or [conda >= 26](https://docs.conda.io/projects/conda/en/latest/index.html) - [Miniforge](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html#term-Miniforge) distribution is recommended
 - [venv - Python's built-in virtual environment tool](https://docs.python.org/3/library/venv.html)
 - [API access token from the Global Fishing Watch API portal](https://globalfishingwatch.org/our-apis/tokens)
 
 ## Installation
 
-You can install `gfw-api-python-client` using `pip`:
+The latest release of `gfw-api-python-client` is available from both the
+[Python Package Index (PyPI)](https://pypi.org/project/gfw-api-python-client/)
+and [conda-forge](https://anaconda.org/conda-forge/gfw-api-python-client).
+
+Install the latest release from [PyPI](https://pypi.org/project/gfw-api-python-client/):
 
 ```bash
 pip install gfw-api-python-client
+```
+
+Install the latest release from [conda-forge](https://anaconda.org/conda-forge/gfw-api-python-client):
+
+```bash
+conda install -c conda-forge gfw-api-python-client
 ```
 
 For detailed instructions—including how to set up a virtual environment—refer to the [Installation Guide](https://globalfishingwatch.github.io/gfw-api-python-client/installation.html) in the documentation.

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -32,10 +32,20 @@ $env:GFW_API_ACCESS_TOKEN = "<PASTE_YOUR_GFW_API_ACCESS_TOKEN_HERE>"
 
 ## Installation
 
-The `gfw-api-python-client` can be easily installed using pip:
+The latest release of `gfw-api-python-client` is available from both the
+[Python Package Index (PyPI)](https://pypi.org/project/gfw-api-python-client/)
+and [conda-forge](https://anaconda.org/conda-forge/gfw-api-python-client).
+
+Install the latest release from [PyPI](https://pypi.org/project/gfw-api-python-client/):
 
 ```bash
 pip install gfw-api-python-client
+```
+
+Install the latest release from [conda-forge](https://anaconda.org/conda-forge/gfw-api-python-client):
+
+```bash
+conda install -c conda-forge gfw-api-python-client
 ```
 
 For more detailed installation instructions, including setting up a virtual environment, please see the dedicated [Installation](installation) section.

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -34,7 +34,7 @@ $env:GFW_API_ACCESS_TOKEN = "<PASTE_YOUR_GFW_API_ACCESS_TOKEN_HERE>"
 
 The latest release of `gfw-api-python-client` is available from both the
 [Python Package Index (PyPI)](https://pypi.org/project/gfw-api-python-client/)
-and [conda-forge](https://anaconda.org/conda-forge/gfw-api-python-client).
+and [Conda](https://anaconda.org/conda-forge/gfw-api-python-client).
 
 Install the latest release from [PyPI](https://pypi.org/project/gfw-api-python-client/):
 
@@ -42,7 +42,7 @@ Install the latest release from [PyPI](https://pypi.org/project/gfw-api-python-c
 pip install gfw-api-python-client
 ```
 
-Install the latest release from [conda-forge](https://anaconda.org/conda-forge/gfw-api-python-client):
+Install the latest release from [Conda](https://anaconda.org/conda-forge/gfw-api-python-client):
 
 ```bash
 conda install -c conda-forge gfw-api-python-client

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -25,6 +25,7 @@ development-guides/index
 apidocs/index
 Releases <https://github.com/GlobalFishingWatch/gfw-api-python-client/releases>
 PyPI <https://pypi.org/project/gfw-api-python-client/>
+Conda <https://anaconda.org/conda-forge/gfw-api-python-client>
 GitHub <https://github.com/GlobalFishingWatch/gfw-api-python-client>
 ```
 

--- a/docs/source/usage-guides/events-api.md
+++ b/docs/source/usage-guides/events-api.md
@@ -50,9 +50,9 @@ print((chn_eez_roi.id, chn_eez_roi.dataset, chn_eez_roi.label, chn_eez_roi.iso3)
 
 **Output:**
 
-````
+```
 ('8486', 'public-eez-areas', 'Chinese Exclusive Economic Zone', 'CHN')
-``
+```
 
 ```python
 events_result = await gfw_client.events.get_all_events(
@@ -62,7 +62,7 @@ events_result = await gfw_client.events.get_all_events(
     region=chn_eez_roi,
     limit=5,
 )
-````
+```
 
 ### Access the list of event as Pydantic models
 

--- a/docs/source/usage-guides/events-api.md
+++ b/docs/source/usage-guides/events-api.md
@@ -50,7 +50,7 @@ print((chn_eez_roi.id, chn_eez_roi.dataset, chn_eez_roi.label, chn_eez_roi.iso3)
 
 **Output:**
 
-```
+````
 ('8486', 'public-eez-areas', 'Chinese Exclusive Economic Zone', 'CHN')
 ``
 
@@ -62,7 +62,7 @@ events_result = await gfw_client.events.get_all_events(
     region=chn_eez_roi,
     limit=5,
 )
-```
+````
 
 ### Access the list of event as Pydantic models
 

--- a/docs/source/workflow-guides/index.md
+++ b/docs/source/workflow-guides/index.md
@@ -2,7 +2,6 @@
 
 The sections below provide detailed instructions on how to combine Global Fishing Watch APIs to build powerful **workflows** and **applications** for a variety of **use cases** using the [gfw-api-python-client](https://github.com/GlobalFishingWatch/gfw-api-python-client). For additional context and expanded explanations, refer to the [API Workflows Guide (PDF)](https://globalfishingwatch.org/our-apis/assets/2025_GFW_API_Workflows.pdf), and [API Workflows](https://globalfishingwatch.org/our-apis/documentation#api-workflows) pages in the [GFW API documentation](https://globalfishingwatch.org/our-apis/documentation#introduction).
 
-
 > **Note:** See the [Datasets](https://globalfishingwatch.org/our-apis/documentation#api-dataset), [Data Caveats](https://globalfishingwatch.org/our-apis/documentation#data-caveat), and [Terms of Use](https://globalfishingwatch.org/our-apis/documentation#terms-of-use) pages in the [GFW API documentation](https://globalfishingwatch.org/our-apis/documentation#introduction) for details on GFW data, API licenses, and rate limits.
 
 ```{toctree}

--- a/notebooks/getting-started.ipynb
+++ b/notebooks/getting-started.ipynb
@@ -76,7 +76,7 @@
     "id": "0bc4eda2-c25f-48ca-a61c-3623b48fbd4d"
    },
    "source": [
-    "The `gfw-api-python-client` can be easily installed using pip:"
+    "The `gfw-api-python-client` can be installed easily from either the [Python Package Index (PyPI)](https://pypi.org/project/gfw-api-python-client/) or [Conda](https://anaconda.org/conda-forge/gfw-api-python-client)"
    ]
   },
   {
@@ -89,6 +89,16 @@
    "outputs": [],
    "source": [
     "# %pip install gfw-api-python-client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b47654b5-2f94-4953-9ce9-50515f2b62fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %conda install -c conda-forge gfw-api-python-client"
    ]
   },
   {

--- a/notebooks/usage-guides/4wings-api.ipynb
+++ b/notebooks/usage-guides/4wings-api.ipynb
@@ -76,7 +76,7 @@
     "id": "e8ed8d6d-214c-4888-bbb9-3798adabe12b"
    },
    "source": [
-    "The `gfw-api-python-client` can be easily installed using pip:"
+    "The `gfw-api-python-client` can be installed easily from either the [Python Package Index (PyPI)](https://pypi.org/project/gfw-api-python-client/) or [Conda](https://anaconda.org/conda-forge/gfw-api-python-client)"
    ]
   },
   {

--- a/notebooks/usage-guides/4wings-api.ipynb
+++ b/notebooks/usage-guides/4wings-api.ipynb
@@ -92,6 +92,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "4408c0f0-aef8-46b1-9e14-245af9c3170b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %conda install -c conda-forge gfw-api-python-client"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "9c023a54-4d23-4cc2-bd36-659d4d78789e",
    "metadata": {

--- a/notebooks/usage-guides/bulk-downloads-api.ipynb
+++ b/notebooks/usage-guides/bulk-downloads-api.ipynb
@@ -76,7 +76,7 @@
     "id": "e8ed8d6d-214c-4888-bbb9-3798adabe12b"
    },
    "source": [
-    "The `gfw-api-python-client` can be easily installed using pip:"
+    "The `gfw-api-python-client` can be installed easily from either the [Python Package Index (PyPI)](https://pypi.org/project/gfw-api-python-client/) or [Conda](https://anaconda.org/conda-forge/gfw-api-python-client)"
    ]
   },
   {

--- a/notebooks/usage-guides/bulk-downloads-api.ipynb
+++ b/notebooks/usage-guides/bulk-downloads-api.ipynb
@@ -92,6 +92,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "3dd9ab7a-710a-450c-84b2-106e6c6dddb6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %conda install -c conda-forge gfw-api-python-client"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "9c023a54-4d23-4cc2-bd36-659d4d78789e",
    "metadata": {

--- a/notebooks/usage-guides/datasets-api.ipynb
+++ b/notebooks/usage-guides/datasets-api.ipynb
@@ -92,6 +92,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b9e2d8a6-cb7e-4341-8056-f00108514fef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %conda install -c conda-forge gfw-api-python-client"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "c8d2ec35-c87b-456e-aecc-35e3e1dfa98d",
    "metadata": {

--- a/notebooks/usage-guides/datasets-api.ipynb
+++ b/notebooks/usage-guides/datasets-api.ipynb
@@ -76,7 +76,7 @@
     "id": "522b8216-70a5-4a4c-ba2c-00181c82dfff"
    },
    "source": [
-    "The `gfw-api-python-client` can be easily installed using pip:"
+    "The `gfw-api-python-client` can be installed easily from either the [Python Package Index (PyPI)](https://pypi.org/project/gfw-api-python-client/) or [Conda](https://anaconda.org/conda-forge/gfw-api-python-client)"
    ]
   },
   {

--- a/notebooks/usage-guides/events-api.ipynb
+++ b/notebooks/usage-guides/events-api.ipynb
@@ -76,7 +76,7 @@
     "id": "e8ed8d6d-214c-4888-bbb9-3798adabe12b"
    },
    "source": [
-    "The `gfw-api-python-client` can be easily installed using pip:"
+    "The `gfw-api-python-client` can be installed easily from either the [Python Package Index (PyPI)](https://pypi.org/project/gfw-api-python-client/) or [Conda](https://anaconda.org/conda-forge/gfw-api-python-client)"
    ]
   },
   {

--- a/notebooks/usage-guides/events-api.ipynb
+++ b/notebooks/usage-guides/events-api.ipynb
@@ -92,6 +92,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "bb737000-011a-424c-8ec1-652de99130f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %conda install -c conda-forge gfw-api-python-client"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "9c023a54-4d23-4cc2-bd36-659d4d78789e",
    "metadata": {

--- a/notebooks/usage-guides/insights-api.ipynb
+++ b/notebooks/usage-guides/insights-api.ipynb
@@ -76,7 +76,7 @@
     "id": "e8ed8d6d-214c-4888-bbb9-3798adabe12b"
    },
    "source": [
-    "The `gfw-api-python-client` can be easily installed using pip:"
+    "The `gfw-api-python-client` can be installed easily from either the [Python Package Index (PyPI)](https://pypi.org/project/gfw-api-python-client/) or [Conda](https://anaconda.org/conda-forge/gfw-api-python-client)"
    ]
   },
   {

--- a/notebooks/usage-guides/insights-api.ipynb
+++ b/notebooks/usage-guides/insights-api.ipynb
@@ -92,6 +92,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "7550203e-7bd8-439d-a54c-994ce2591986",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %conda install -c conda-forge gfw-api-python-client"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "9c023a54-4d23-4cc2-bd36-659d4d78789e",
    "metadata": {

--- a/notebooks/usage-guides/references-data-api.ipynb
+++ b/notebooks/usage-guides/references-data-api.ipynb
@@ -76,7 +76,7 @@
     "id": "0b5ca4e9-9577-4b47-9c40-3ac44c80b3c0"
    },
    "source": [
-    "The `gfw-api-python-client` can be easily installed using pip:"
+    "The `gfw-api-python-client` can be installed easily from either the [Python Package Index (PyPI)](https://pypi.org/project/gfw-api-python-client/) or [Conda](https://anaconda.org/conda-forge/gfw-api-python-client)"
    ]
   },
   {

--- a/notebooks/usage-guides/references-data-api.ipynb
+++ b/notebooks/usage-guides/references-data-api.ipynb
@@ -92,6 +92,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "96c5ac02-1f49-45a2-adc6-359930e1ce32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %conda install -c conda-forge gfw-api-python-client"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "1a2c04fd-1741-49c5-a5b4-28330338066c",
    "metadata": {

--- a/notebooks/usage-guides/vessels-api.ipynb
+++ b/notebooks/usage-guides/vessels-api.ipynb
@@ -76,7 +76,7 @@
     "id": "e8ed8d6d-214c-4888-bbb9-3798adabe12b"
    },
    "source": [
-    "The `gfw-api-python-client` can be easily installed using pip:"
+    "The `gfw-api-python-client` can be installed easily from either the [Python Package Index (PyPI)](https://pypi.org/project/gfw-api-python-client/) or [Conda](https://anaconda.org/conda-forge/gfw-api-python-client)"
    ]
   },
   {

--- a/notebooks/usage-guides/vessels-api.ipynb
+++ b/notebooks/usage-guides/vessels-api.ipynb
@@ -92,6 +92,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d17a8a1e-a2a6-4c88-afbc-691b35d92e25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %conda install -c conda-forge gfw-api-python-client"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "9c023a54-4d23-4cc2-bd36-659d4d78789e",
    "metadata": {

--- a/notebooks/workflow-guides/workflow-01-analyze-apparent-fishing-effort-senegalese-eez.ipynb
+++ b/notebooks/workflow-guides/workflow-01-analyze-apparent-fishing-effort-senegalese-eez.ipynb
@@ -61,7 +61,7 @@
    "id": "af48cf4e-e24c-47aa-a2c5-64cf87be9c33",
    "metadata": {},
    "source": [
-    "The `gfw-api-python-client` can be easily installed using pip:"
+    "The `gfw-api-python-client` can be installed easily from either the [Python Package Index (PyPI)](https://pypi.org/project/gfw-api-python-client/) or [Conda](https://anaconda.org/conda-forge/gfw-api-python-client)"
    ]
   },
   {
@@ -72,6 +72,16 @@
    "outputs": [],
    "source": [
     "# %pip install gfw-api-python-client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cac67e76-37af-4031-a714-394ea172a788",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %conda install -c conda-forge gfw-api-python-client"
    ]
   },
   {

--- a/notebooks/workflow-guides/workflow-02-analyze-apparent-fishing-effort-argentinian-eez.ipynb
+++ b/notebooks/workflow-guides/workflow-02-analyze-apparent-fishing-effort-argentinian-eez.ipynb
@@ -61,7 +61,7 @@
    "id": "af48cf4e-e24c-47aa-a2c5-64cf87be9c33",
    "metadata": {},
    "source": [
-    "The `gfw-api-python-client` can be easily installed using pip:"
+    "The `gfw-api-python-client` can be installed easily from either the [Python Package Index (PyPI)](https://pypi.org/project/gfw-api-python-client/) or [Conda](https://anaconda.org/conda-forge/gfw-api-python-client)"
    ]
   },
   {
@@ -72,6 +72,16 @@
    "outputs": [],
    "source": [
     "# %pip install gfw-api-python-client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f13834fa-97f4-4b17-81f4-6ee38bb3d900",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %conda install -c conda-forge gfw-api-python-client"
    ]
   },
   {

--- a/notebooks/workflow-guides/workflow-03-analyze-fleet-in-ghanaian-eez.ipynb
+++ b/notebooks/workflow-guides/workflow-03-analyze-fleet-in-ghanaian-eez.ipynb
@@ -61,7 +61,7 @@
    "id": "af48cf4e-e24c-47aa-a2c5-64cf87be9c33",
    "metadata": {},
    "source": [
-    "The `gfw-api-python-client` can be easily installed using pip:"
+    "The `gfw-api-python-client` can be installed easily from either the [Python Package Index (PyPI)](https://pypi.org/project/gfw-api-python-client/) or [Conda](https://anaconda.org/conda-forge/gfw-api-python-client)"
    ]
   },
   {
@@ -72,6 +72,16 @@
    "outputs": [],
    "source": [
     "# %pip install gfw-api-python-client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b08785d2-a45e-4398-8b99-4a9ab6a87182",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %conda install -c conda-forge gfw-api-python-client"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,61 +75,61 @@ dependencies = [
 [project.optional-dependencies]
 # Linting and code quality tools
 lint = [
-  "black[jupyter]>=26.1.0",      # Code formatting tool
-  "isort>=7.0.0",                # Python imports sorting tool
-  "mypy>=1.19.1",                # Static type checker
+  "black[jupyter]>=26.5.1",      # Code formatting tool
+  "isort>=8.0.1",                # Python imports sorting tool
+  "mypy>=2.3.0",                 # Static type checker
   "pydocstyle>=6.3.0",           # Python docstring style checker
-  "ruff>=0.14.14",                # Linter and code analysis tool
-  "codespell[toml]>=2.4.1",      # Spell checker for code
+  "ruff>=0.16.0",                # Linter and code analysis tool
+  "codespell[toml]>=2.4.3",      # Spell checker for code
 ]
 
 # Testing tools
 test = [
-  "pytest>=9.0.2",            # Core testing framework
-  "pytest-asyncio>=1.3.0",    # Asyncio plugin for pytest
-  "pytest-cov>=7.0.0",        # Coverage plugin for pytest
+  "pytest>=9.1.1",            # Core testing framework
+  "pytest-asyncio>=1.4.0",    # Asyncio plugin for pytest
+  "pytest-cov>=7.1.0",        # Coverage plugin for pytest
   "pytest-mock>=3.15.1",      # Mocking plugin for pytest
   "pytest-xdist>=3.8.0",      # Parallel test execution for pytest
   "pytest-timeout>=2.4.0",    # Timeout support for pytest
-  "coverage[toml]>=7.11.0",   # Code coverage reporting
-  "respx>=0.22.0",            # Utility for mocking httpx
+  "coverage[toml]>=7.15.2",   # Code coverage reporting
+  "respx>=0.23.1",            # Utility for mocking httpx
 ]
 
 # Development workflow and tools
 dev = [
-  "commitizen>=4.12.1",        # Standardized commit messages and versioning
-  "pre-commit>=4.5.1",        # Framework for managing pre-commit hooks
-  "pip-audit>=2.10.0",         # Audit for finding vulnerabilities in dependencies
+  "commitizen>=4.17.0",        # Standardized commit messages and versioning
+  "pre-commit>=4.6.1",         # Framework for managing pre-commit hooks
+  "pip-audit>=2.10.1",         # Audit for finding vulnerabilities in dependencies
 ]
 
 # Build tools
 build = [
-  "build>=1.4.0",                 # Python PEP 517 compliant build system
+  "build>=1.5.0",                 # Python PEP 517 compliant build system
   "check-wheel-contents>=0.6.3",  # Check wheels have the right contents
   "pydistcheck>=0.11.3",          # Inspect Python package distributions for common problems
-  "pyroma>=5.0.1",                  # Test project's packaging friendliness
-  "setuptools>=80.10.2",           # Python packaging library
-  "twine>=6.2.0",                 # For uploading Python packages to PyPI
+  "pyroma>=5.0.1",                # Test project's packaging friendliness
+  "setuptools>=83.0.0",           # Python packaging library
+  "twine>=7.0.0",                 # For uploading Python packages to PyPI
 ]
 
 # Documentation tools
 docs = [
-  "sphinx>=9.0.4",                  # Tool for generating documentation
-  "furo>=2025.12.19",                # Sphinx theme for beautiful documentation
-  "myst-parser>=5.0.0",             # Writing documentation with Markdown in Sphinx
-  "myst-nb>=1.3.0",                 # Writing documentation with Jupyter Notebook in Sphinx
-  "sphinx-copybutton>=0.5.2",       # Add a "copy" button to code blocks in Sphinx
-  "sphinx-autobuild>=2025.8.25",    # Build, watch and serve documentation with live reload in the browser
+  "sphinx>=9.0.4",                      # Tool for generating documentation
+  "furo>=2025.12.19",                   # Sphinx theme for beautiful documentation
+  "myst-parser>=5.1.0",                 # Writing documentation with Markdown in Sphinx
+  "myst-nb>=1.4.0",                     # Writing documentation with Jupyter Notebook in Sphinx
+  "sphinx-copybutton>=0.5.2",           # Add a "copy" button to code blocks in Sphinx
+  "sphinx-autobuild>=2025.8.25",        # Build, watch and serve documentation with live reload in the browser
   "sphinx-inline-tabs>=2025.12.21.14",  # Add inline tabbed content to documentation
-  "sphinx-autodoc2>=0.5.0",         # Generates API documentation for Python packages
+  "sphinx-autodoc2>=0.5.0",             # Generates API documentation for Python packages
 ]
 
 # Jupyter notebook and interactive tools
 notebooks = [
-  "ipykernel>=7.1.0",         # Jupyter kernel for Python
-  "ipython>=9.9.0",           # Enhanced interactive Python shell
-  "jupyterlab>=4.5.3",       # Jupyter's next-generation web-based interface
-  "watermark>=2.6.0",         # Add timestamps and version info to Jupyter notebook
+  "ipykernel>=7.3.0",          # Jupyter kernel for Python
+  "ipython>=9.15.0",           # Enhanced interactive Python shell
+  "jupyterlab>=4.6.2",         # Jupyter's next-generation web-based interface
+  "watermark>=2.6.0",          # Add timestamps and version info to Jupyter notebook
 ]
 
 

--- a/src/gfwapiclient/exceptions/__init__.py
+++ b/src/gfwapiclient/exceptions/__init__.py
@@ -70,7 +70,6 @@ __all__ = [
     "RequestParamsValidationError",
     "RequestTimeoutError",
     "ResultItemValidationError",
-    "ResultItemValidationError",
     "ResultValidationError",
     "ServiceUnavailableError",
     "UnprocessableEntityError",


### PR DESCRIPTION
This:
- Add `Conda` installation, environment creation, and package upgrade instructions
- Document `Conda` workflows alongside existing `pip/venv` setup guidance
- Update `README` installation and requirements sections for both `pip` and `Conda` users
- Add the `conda-forge` project link to the documentation index